### PR TITLE
Add 47933.patch

### DIFF
--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -1112,7 +1112,7 @@ JL_DLLEXPORT void jl_print_backtrace(void) JL_NOTSAFEPOINT
 // Print backtraces for all live tasks, for all threads.
 // WARNING: this is dangerous and can crash if used outside of gdb, if
 // all of Julia's threads are not stopped!
-JL_DLLEXPORT void jl_print_task_backtraces(void) JL_NOTSAFEPOINT
+JL_DLLEXPORT void jl_print_task_backtraces(int show_done) JL_NOTSAFEPOINT
 {
     for (size_t i = 0; i < jl_n_threads; i++) {
         jl_ptls_t ptls2 = jl_all_tls_states[i];
@@ -1130,9 +1130,13 @@ JL_DLLEXPORT void jl_print_task_backtraces(void) JL_NOTSAFEPOINT
         void **lst = live_tasks->items;
         for (size_t j = 0; j < live_tasks->len; j++) {
             jl_task_t *t = (jl_task_t *)lst[j];
+            int t_state = jl_atomic_load_relaxed(&t->_state);
+            if (!show_done && t_state == JL_TASK_STATE_DONE) {
+                continue;
+            }
             jl_safe_printf("     ---- Task %zu (%p)\n", j + 1, t);
             jl_safe_printf("          (sticky: %d, started: %d, state: %d, tid: %d)\n",
-                    t->sticky, t->started, jl_atomic_load_relaxed(&t->_state),
+                    t->sticky, t->started, t_state,
                     jl_atomic_load_relaxed(&t->tid) + 1);
             if (t->stkbuf != NULL)
                 jlbacktracet(t);


### PR DESCRIPTION
Add option to `jl_print_task_backtraces(bool)` to control whether or not to print DONE tasks (https://github.com/JuliaLang/julia/pull/47933).

To be merged once the backport is merged in RelationalAI's code