### PR TITLE
Kiran's Add last_full_sweep to GC stats

### DIFF
--- a/base/timing.jl
+++ b/base/timing.jl
@@ -25,6 +25,7 @@ struct GC_Num
     mark_time       ::Int64
     total_sweep_time  ::Int64
     total_mark_time   ::Int64
+    last_full_sweep ::Int64
 end
 
 gc_num() = ccall(:jl_gc_num, GC_Num, ())

--- a/src/gc.c
+++ b/src/gc.c
@@ -3278,6 +3278,8 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection)
     uint64_t sweep_time = gc_end_time - start_sweep_time;
     gc_num.total_sweep_time += sweep_time;
     gc_num.sweep_time = sweep_time;
+    if (sweep_full)
+        gc_num.last_full_sweep = gc_end_time;
 
     // sweeping is over
     // 6. if it is a quick sweep, put back the remembered objects in queued state

--- a/src/gc.h
+++ b/src/gc.h
@@ -82,6 +82,7 @@ typedef struct {
     uint64_t    mark_time;
     uint64_t    total_sweep_time;
     uint64_t    total_mark_time;
+    uint64_t    last_full_sweep;
 } jl_gc_num_t;
 
 enum {


### PR DESCRIPTION
Just to save us time I opened a PR with Kiran's patch to Julia 1.8.2-RAI so we can use this patch is master.

> Whenever the GC runs a full sweep, it records the time_ns() at which the full sweep completed in GC_Num.
This should be replaced by backporting the upstream PR, when we open that.

