### PR TITLE
Use tempdir() to store heap snapshot files

### DIFF
--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -1262,7 +1262,7 @@ function take_heap_snapshot(filepath::String, all_one::Bool=false)
     return filepath
 end
 function take_heap_snapshot(all_one::Bool=false)
-    f = abspath("$(getpid())_$(time_ns()).heapsnapshot")
+    f = joinpath(tempdir(), "$(getpid())_$(time_ns()).heapsnapshot")
     return take_heap_snapshot(f, all_one)
 end
 


### PR DESCRIPTION
in RAICloud, the directory `/` is not accessible and it should not be.