### PR TITLE
Disable huge pages for every mmap call

### DIFF
--- a/src/gc-pages.c
+++ b/src/gc-pages.c
@@ -74,6 +74,10 @@ static char *jl_gc_try_alloc_pages(int pg_cnt) JL_NOTSAFEPOINT
         return NULL;
     poolmem_bytes_allocated += pages_sz;
     poolmem_blocks_allocated_total++;
+
+#ifdef MADV_NOHUGEPAGE
+    madvise(mem, pages_sz, MADV_NOHUGEPAGE);
+#endif
 #endif
     if (GC_PAGE_SZ > jl_page_size)
         // round data pointer up to the nearest gc_page_data-aligned

--- a/src/gc-stacks.c
+++ b/src/gc-stacks.c
@@ -61,6 +61,9 @@ static void *malloc_stack(size_t bufsz) JL_NOTSAFEPOINT
         munmap(stk, bufsz);
         return MAP_FAILED;
     }
+#ifdef MADV_NOHUGEPAGE
+    madvise(stk, bufsz, MADV_NOHUGEPAGE);
+#endif
 #endif
     jl_atomic_fetch_add(&num_stack_mappings, 1);
     return stk;

--- a/src/gc.c
+++ b/src/gc.c
@@ -3843,6 +3843,9 @@ void *jl_gc_perm_alloc_nolock(size_t sz, int zero, unsigned align, unsigned offs
     errno = last_errno;
     if (__unlikely(pool == MAP_FAILED))
         return NULL;
+#ifdef MADV_NOHUGEPAGE
+    madvise(pool, GC_PERM_POOL_SIZE, MADV_NOHUGEPAGE);
+#endif
 #endif
     gc_perm_pool = (uintptr_t)pool;
     gc_perm_end = gc_perm_pool + GC_PERM_POOL_SIZE;


### PR DESCRIPTION
Disable huge page to avoid THP collapsing ranges of smaller 4 KiB pages into huge pages that can waste lots of memory e.g., when we create lots of tasks.
cf.[ raicode PR](https://github.com/RelationalAI/raicode/pull/14546)