### PR TITLE
Bck v1.9.2+rai+madv free

### DIFF
--- a/src/gc-pages.c
+++ b/src/gc-pages.c
@@ -335,7 +335,7 @@ void jl_gc_free_page(void *p) JL_NOTSAFEPOINT
     }
 #ifdef _OS_WINDOWS_
     VirtualFree(p, decommit_size, MEM_DECOMMIT);
-#elif defined(MADV_FREE)
+#elif 0
     static int supports_madv_free = 1;
     if (supports_madv_free) {
         if (madvise(p, decommit_size, MADV_FREE) == -1) {


### PR DESCRIPTION
Disable MADV_FREE. Use MADV_DONTNEED.

See https://github.com/RelationalAI/raicode/pull/15092