### PR TITLE
Fix pool live bytes merge

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -3356,6 +3356,7 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection)
     }
     scanned_bytes = 0;
     // 6. start sweeping
+    pool_live_bytes = 0;
     uint64_t start_sweep_time = jl_hrtime();
     JL_PROBE_GC_SWEEP_BEGIN(sweep_full);
     sweep_weak_refs();


### PR DESCRIPTION
resetting pool_live_bytes after each GC accidentally got removed when merging the parallel marking [PR](https://github.com/RelationalAI/julia/commit/6085d74ea73b2cace6fe1a608a19fc6bc6f1a1a1#diff-76b4d6ef0f7d9c2a6855e1ef7b0f7c94ddc68fcca2cdcd69e6d2b9007c279fde) 