### PR TITLE
Backport https://github.com/JuliaLang/julia/pull/51301: export num_stack_mappings

### DIFF
--- a/src/gc-stacks.c
+++ b/src/gc-stacks.c
@@ -76,6 +76,10 @@ static void free_stack(void *stkbuf, size_t bufsz)
 }
 #endif
 
+JL_DLLEXPORT uint32_t jl_get_num_stack_mappings(void)
+{
+    return jl_atomic_load_relaxed(&num_stack_mappings);
+}
 
 const unsigned pool_sizes[] = {
     128 * 1024,

--- a/src/gc.h
+++ b/src/gc.h
@@ -644,6 +644,7 @@ void gc_count_pool(void);
 size_t jl_array_nbytes(jl_array_t *a) JL_NOTSAFEPOINT;
 
 JL_DLLEXPORT void jl_enable_gc_logging(int enable);
+JL_DLLEXPORT uint32_t jl_get_num_stack_mappings(void);
 void _report_gc_finished(uint64_t pause, uint64_t freed, int full, int recollect) JL_NOTSAFEPOINT;
 
 #ifdef __cplusplus

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -327,3 +327,9 @@ end
     @test_throws ArgumentError @macroexpand(@threads 1) # arg isn't an Expr
     @test_throws ArgumentError @macroexpand(@threads if true 1 end) # arg doesn't start with for
 end
+
+@testset "num_stack_mappings metric" begin
+    @test @ccall(jl_get_num_stack_mappings()::Cint) >= 1
+    # There must be at least two: one for the root test task and one for the async task:
+    @test fetch(@async(@ccall(jl_get_num_stack_mappings()::Cint))) >= 2
+end


### PR DESCRIPTION
Backport https://github.com/JuliaLang/julia/pull/51301: export num_stack_mappings

Export num_stack_mappings to track the number of in-flight stack mappings and tasks in application #51301