### PR TITLE
Add GitHub template and workflows needed on the default branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,0 @@
-CODEOWNERS @JuliaLang/github-actions
-/.github/ @JuliaLang/github-actions
-/.buildkite/ @JuliaLang/github-actions
-
-/.github/workflows/rerun_failed.yml @DilumAluthge
-/.github/workflows/statuses.yml @DilumAluthge

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+<!---
+PRs to RelationalAI/julia must be opened to the correct branch (see
+https://github.com/RelationalAI/raicode/blob/master/nix/julia-version.json).
+-->
+## PR Description
+
+_What does this PR do?_
+
+## Checklist
+
+Requirements for merging:
+- [ ] I have opened an issue or PR upstream on JuliaLang/julia: <link to JuliaLang/julia>
+- [ ] I have removed the `port-to-*` labels that don't apply.

--- a/.github/workflows/LabelCheck.yml
+++ b/.github/workflows/LabelCheck.yml
@@ -1,0 +1,19 @@
+name: Labels
+
+permissions:
+  contents: read
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, reopened, edited, synchronize]
+jobs:
+  enforce-labels:
+    name: Check for blocking labels
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+    - uses: yogevbd/enforce-label-action@2.2.2
+      with:
+        # REQUIRED_LABELS_ANY: "bug,enhancement,skip-changelog"
+        # REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label ['bug','enhancement','skip-changelog']"
+        BANNED_LABELS: "needs docs,needs compat annotation,needs more info,needs nanosoldier run,needs news,needs pkgeval,needs tests,DO NOT MERGE"
+        BANNED_LABELS_DESCRIPTION: "A PR should not be merged with `needs *` or `DO NOT MERGE` labels"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,17 @@
+# See https://github.com/actions/labeler
+name: "Pull Request Labeler"
+on:
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        dot: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,16 @@
+name: "Close stale PRs"
+on:
+  schedule:
+  - cron: "0 0 * * *" # every night at midnight
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v8
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Comment or remove stale label, or this PR will be closed in 5 days.'
+        days-before-stale: 30
+        days-before-close: 5
+        stale-pr-label: 'stale'


### PR DESCRIPTION
We want to set the default branch on this repo to be the version that we're currently using, which is `v1.9.2+RAI`, but the PR template and the workflows that run on a schedule must be in the default branch... so this PR adds those GitHub things to `v1.9.2+RAI`.
this PR
- copies the files from `master+RAI` (current default)
- removes the `codeowerns` file that doesn't apply to this fork (we could always add our own one back later)
- adds a workflow for closing stale PRs [this change can move to it's own PR if you prefer?]

in future, when we change default branch, it should be a simple as copying across the `.github/` directory, e.g.
```
git checkout new-default-branch                # switch to new branch
git checkout old-default-branch -- .github/    # copy across the files from the old branch
git commit -m "add github setup needed when default branch"
```