### PR TITLE
[RAI-16458] Add workflow to keep up-to-date with upstream branches

### DIFF
--- a/.github/workflows/update-upstream-branches.yml
+++ b/.github/workflows/update-upstream-branches.yml
@@ -1,0 +1,28 @@
+name: "Update upstream branches"
+on:
+  schedule:
+    - cron: "0 0 * * *" # every night at midnight
+  workflow_dispatch:
+
+jobs:
+  PullUpstream:
+    strategy:
+      fail-fast: false  # run all jobs in the matrix even if one fails
+      matrix:
+        branch:
+          - "master"
+          - "backports-release-1.10"
+          - "backports-release-1.9"
+    steps:
+      - name: Checkout RAI/julia
+        uses: actions/checkout@v3
+        with:
+          ref: RelationalAI/julia
+      - name: Update ${{ branch }}
+        run: |
+          git config --global user.email "julia-engineering@relational.ai"
+          git config --global user.name "RAI CI (GitHub Action Automation)"
+
+          git remote add upstream https://github.com/JuliaLang/julia
+          git pull upstream ${{ branch }}
+          git push origin ${{ branch }}


### PR DESCRIPTION
- close RAI-16458
- makes it easier to see RAI-specific changes (e.g. comparisons PRs like https://github.com/RelationalAI/julia/pull/46 would have clearer/smaller diffs)
- PR is to the default branch, since scheduled workflows need to be on default branch
  - (but no way to test a new GitHub workflow before it's merged 😞)
