### PR TITLE
Backport don't print task backtrace for GC threads

### DIFF
--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -1136,6 +1136,8 @@ JL_DLLEXPORT void jl_print_backtrace(void) JL_NOTSAFEPOINT
     jlbacktrace();
 }
 
+extern int gc_first_tid;
+
 // Print backtraces for all live tasks, for all threads.
 // WARNING: this is dangerous and can crash if used outside of gdb, if
 // all of Julia's threads are not stopped!
@@ -1144,6 +1146,10 @@ JL_DLLEXPORT void jl_print_task_backtraces(int show_done) JL_NOTSAFEPOINT
     size_t nthreads = jl_atomic_load_acquire(&jl_n_threads);
     jl_ptls_t *allstates = jl_atomic_load_relaxed(&jl_all_tls_states);
     for (size_t i = 0; i < nthreads; i++) {
+        // skip GC threads since they don't have tasks
+        if (gc_first_tid <= i && i < gc_first_tid + jl_n_gcthreads) {
+            continue;
+        }
         jl_ptls_t ptls2 = allstates[i];
         arraylist_t *live_tasks = &ptls2->heap.live_tasks;
         size_t n = live_tasks->len;


### PR DESCRIPTION
<!---
PRs to RelationalAI/julia must be opened to the correct branch (see
https://github.com/RelationalAI/raicode/blob/master/nix/julia-version.json).
-->
## PR Description

Backport https://github.com/JuliaLang/julia/pull/51413.

## Checklist

Requirements for merging:
- [X] I have opened an issue or PR upstream on JuliaLang/julia: https://github.com/JuliaLang/julia/pull/51413
- [X] I have removed the `port-to-*` labels that don't apply.
