### PR TITLE
Fix workflow that pulls upstream branches

### DIFF
--- a/.github/workflows/update-upstream-branches.yml
+++ b/.github/workflows/update-upstream-branches.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   PullUpstream:
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false  # run all jobs in the matrix even if one fails
       matrix:

--- a/.github/workflows/update-upstream-branches.yml
+++ b/.github/workflows/update-upstream-branches.yml
@@ -18,11 +18,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: RelationalAI/julia
-      - name: Update ${{ branch }}
+      - name: Update ${{ matrix.branch }}
         run: |
           git config --global user.email "julia-engineering@relational.ai"
           git config --global user.name "RAI CI (GitHub Action Automation)"
 
           git remote add upstream https://github.com/JuliaLang/julia
-          git pull upstream ${{ branch }}
-          git push origin ${{ branch }}
+          git pull upstream ${{ matrix.branch }}
+          git push origin ${{ matrix.branch }}

--- a/.github/workflows/update-upstream-branches.yml
+++ b/.github/workflows/update-upstream-branches.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout RAI/julia
         uses: actions/checkout@v3
         with:
-          ref: RelationalAI/julia
+          ref: ${{ matrix.branch }}
       - name: Update ${{ matrix.branch }}
         run: |
           git config --global user.email "julia-engineering@relational.ai"


### PR DESCRIPTION
You can see this workflow now ran successfully with these fixes: https://github.com/RelationalAI/julia/actions/runs/6325571167

Follow-up to https://github.com/RelationalAI/julia/pull/76. Sorry for the follow-up PR; we can only test a GitHub Actions workflow once it's already on the default branch.