### PR TITLE
Change backtrace prefix of thread ID to 1-based

### DIFF
--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -662,7 +662,7 @@ void jl_print_bt_entry_codeloc(int sig, jl_bt_element_t *bt_entry) JL_NOTSAFEPOI
     if (sig != -1) {
         snprintf(sig_str, 32, "signal (%d) ", sig);
     }
-    snprintf(pre_str, 64, "%sthread (%d) ", sig_str, jl_threadid());
+    snprintf(pre_str, 64, "%sthread (%d) ", sig_str, jl_threadid() + 1);
 
     if (jl_bt_is_native(bt_entry)) {
         jl_print_native_codeloc(pre_str, bt_entry[0].uintptr);
@@ -1118,7 +1118,7 @@ static void jl_rec_backtrace(jl_task_t *t) JL_NOTSAFEPOINT
 JL_DLLEXPORT void jl_gdblookup(void* ip)
 {
     char pre_str[64];
-    snprintf(pre_str, 64, "thread (%d) ", jl_threadid());
+    snprintf(pre_str, 64, "thread (%d) ", jl_threadid() + 1);
     jl_print_native_codeloc(pre_str, (uintptr_t)ip);
 }
 


### PR DESCRIPTION
<!---
PRs to RelationalAI/julia must be opened to the correct branch (see
https://github.com/RelationalAI/raicode/blob/master/nix/julia-version.json).
-->
## PR Description

Currently the output is 0-based, so we see:
```
...
thread (0) ijl_apply_generic at /nix/store/6lxp69px3vnal0csypfvm3lv2dwlllwv-julia-1.9.2/lib/julia/libjulia-internal.1.9.dylib (unknown line)
thread (0) do_call at /nix/store/6lxp69px3vnal0csypfvm3lv2dwlllwv-julia-1.9.2/lib/julia/libjulia-internal.1.9.dylib (unknown line)
...
```
In Julia, thread ID is 1-based, so this output is wrong. This PR fixes that.

This has a messy history. The following commits should be merged with this one when we next upgrade:
- `0457f8995eb49158adcab9b12d21d9d31e9e05d4`
- `e015382634953445155c9fa4f51aba05235e8313`
- `8f409da5c564d8fd9e9a2d0fe19235a710fedd09`

## Checklist

Requirements for merging:
- [X] I have opened an issue or PR upstream on JuliaLang/julia: https://github.com/JuliaLang/julia/issues/51056
- [X] I have removed the `port-to-*` labels that don't apply.
- [X] I have opened a PR on raicode to test these changes: https://github.com/RelationalAI/raicode/pull/15745
