### PR TITLE
Backport stop running finalizers on exit

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -295,9 +295,6 @@ JL_DLLEXPORT void jl_atexit_hook(int exitcode)
     JL_STDOUT = (uv_stream_t*) STDOUT_FILENO;
     JL_STDERR = (uv_stream_t*) STDERR_FILENO;
 
-    if (ct)
-        jl_gc_run_all_finalizers(ct);
-
     uv_loop_t *loop = jl_global_event_loop();
     if (loop != NULL) {
         struct uv_shutdown_queue queue = {NULL, NULL};


### PR DESCRIPTION
<!---
PRs to RelationalAI/julia must be opened to the correct branch (see
https://github.com/RelationalAI/raicode/blob/master/nix/julia-version.json).
-->
## PR Description

Testing the key part of 51466.

## Checklist

Requirements for merging:
- [X] I have opened an issue or PR upstream on JuliaLang/julia: https://github.com/JuliaLang/julia/pull/51466
- [X] I have removed the `port-to-*` labels that don't apply.
- [X] I have opened a PR on raicode to test these changes: https://github.com/RelationalAI/raicode/pull/15768
