### PR TITLE
Revert "inference: follow up the `Vararg` fix in `abstract_call_unionall` (#51403)"

### DIFF
--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -5106,11 +5106,3 @@ end
 @test code_typed() do
     b{c} = d...
 end |> only |> first isa Core.CodeInfo
-
-abstract_call_unionall_vararg(some::Some{Any}) = UnionAll(some.value...)
-@test only(Base.return_types(abstract_call_unionall_vararg)) !== Union{}
-let TV = TypeVar(:T)
-    t = Vector{TV}
-    some = Some{Any}((TV, t))
-    @test abstract_call_unionall_vararg(some) isa UnionAll
-end


### PR DESCRIPTION
Until this is resolved upstream, let's back this PR out of **our build**, so that we can continue to detect new failures.


This reverts commit ae8f9ad5b8c5f5b0c217d99e83657405dbeb1913.

<!---
PRs to RelationalAI/julia must be opened to the correct branch (see
https://github.com/RelationalAI/raicode/blob/master/nix/julia-version.json).
-->
## PR Description

## Checklist

Requirements for merging:
- [x] I have opened an issue or PR upstream on JuliaLang/julia: https://github.com/JuliaLang/julia/pull/51612
- [ ] I have removed the `port-to-*` labels that don't apply.
- [ ] I have opened a PR on raicode to test these changes: <link to raicode>
