### PR TITLE
Prepend "thread (%d)" to output from `jl_print_task_backtraces()`

### DIFF
--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -1163,6 +1163,8 @@ JL_DLLEXPORT void jl_print_task_backtraces(int show_done) JL_NOTSAFEPOINT
 {
     size_t nthreads = jl_atomic_load_acquire(&jl_n_threads);
     jl_ptls_t *allstates = jl_atomic_load_relaxed(&jl_all_tls_states);
+    int ctid = jl_threadid() + 1;
+    jl_safe_printf("thread (%d) ++++ Task backtraces\n", ctid);
     for (size_t i = 0; i < nthreads; i++) {
         // skip GC threads since they don't have tasks
         if (gc_first_tid <= i && i < gc_first_tid + jl_n_gcthreads) {
@@ -1178,22 +1180,22 @@ JL_DLLEXPORT void jl_print_task_backtraces(int show_done) JL_NOTSAFEPOINT
         jl_task_t *t = ptls2->root_task;
         if (t != NULL)
             t_state = jl_atomic_load_relaxed(&t->_state);
-        jl_safe_printf("==== Thread %d created %zu live tasks\n",
-                ptls2->tid + 1, n + (t_state != JL_TASK_STATE_DONE));
+        jl_safe_printf("thread (%d) ==== Thread %d created %zu live tasks\n",
+                ctid, ptls2->tid + 1, n + (t_state != JL_TASK_STATE_DONE));
         if (show_done || t_state != JL_TASK_STATE_DONE) {
-            jl_safe_printf("     ---- Root task (%p)\n", ptls2->root_task);
+            jl_safe_printf("thread (%d)     ---- Root task (%p)\n", ctid, ptls2->root_task);
             if (t != NULL) {
-                jl_safe_printf("          (sticky: %d, started: %d, state: %d, tid: %d)\n",
-                        t->sticky, t->started, t_state,
+                jl_safe_printf("thread (%d)          (sticky: %d, started: %d, state: %d, tid: %d)\n",
+                        ctid, t->sticky, t->started, t_state,
                         jl_atomic_load_relaxed(&t->tid) + 1);
                 if (t->stkbuf != NULL) {
                     jlbacktracet(t);
                 }
                 else {
-                    jl_safe_printf("      no stack\n");
+                    jl_safe_printf("thread (%d)      no stack\n", ctid);
                 }
             }
-            jl_safe_printf("     ---- End root task\n");
+            jl_safe_printf("thread (%d)     ---- End root task\n", ctid);
         }
 
         for (size_t j = 0; j < n; j++) {
@@ -1203,20 +1205,20 @@ JL_DLLEXPORT void jl_print_task_backtraces(int show_done) JL_NOTSAFEPOINT
             int t_state = jl_atomic_load_relaxed(&t->_state);
             if (!show_done && t_state == JL_TASK_STATE_DONE)
                 continue;
-            jl_safe_printf("     ---- Task %zu (%p)\n", j + 1, t);
+            jl_safe_printf("thread (%d)     ---- Task %zu (%p)\n", ctid, j + 1, t);
             // n.b. this information might not be consistent with the stack printing after it, since it could start running or change tid, etc.
-            jl_safe_printf("          (sticky: %d, started: %d, state: %d, tid: %d)\n",
-                    t->sticky, t->started, t_state,
+            jl_safe_printf("thread (%d)          (sticky: %d, started: %d, state: %d, tid: %d)\n",
+                    ctid, t->sticky, t->started, t_state,
                     jl_atomic_load_relaxed(&t->tid) + 1);
             if (t->stkbuf != NULL)
                 jlbacktracet(t);
             else
-                jl_safe_printf("      no stack\n");
-            jl_safe_printf("     ---- End task %zu\n", j + 1);
+                jl_safe_printf("thread (%d)      no stack\n", ctid);
+            jl_safe_printf("thread (%d)     ---- End task %zu\n", ctid, j + 1);
         }
-        jl_safe_printf("==== End thread %d\n", ptls2->tid + 1);
+        jl_safe_printf("thread (%d) ==== End thread %d\n", ctid, ptls2->tid + 1);
     }
-    jl_safe_printf("==== Done\n");
+    jl_safe_printf("thread (%d) ++++ Done\n", ctid);
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
<!---
PRs to RelationalAI/julia must be opened to the correct branch (see
https://github.com/RelationalAI/raicode/blob/master/nix/julia-version.json).
-->
## PR Description

More backtrace prepending, this time to the text output by `jl_print_task_backtraces()`.

This should be squashed with the following commits when we upgrade:
- `0457f8995eb49158adcab9b12d21d9d31e9e05d4`
- `e015382634953445155c9fa4f51aba05235e8313`
- `8f409da5c564d8fd9e9a2d0fe19235a710fedd09`

## Checklist

Requirements for merging:
- [X] I have opened an issue or PR upstream on JuliaLang/julia: https://github.com/JuliaLang/julia/issues/51056
- [X] I have removed the `port-to-*` labels that don't apply.
- [X] I have opened a PR on raicode to test these changes: https://github.com/RelationalAI/raicode/pull/15869
