### PR TITLE
missing gc_mark_push_remset in obj32

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -2048,6 +2048,7 @@ STATIC_INLINE jl_value_t *gc_mark_obj32(jl_ptls_t ptls, char *obj32_parent, uint
             gc_heap_snapshot_record_object_edge((jl_value_t*)obj32_parent, slot);
         }
     }
+    gc_mark_push_remset(ptls, (jl_value_t *)obj32_parent, nptr);
     return new_obj;
 }
 


### PR DESCRIPTION
## PR Description

This was fixed upstream a while back. We didn't backport the fix for some reason.

## Checklist

Requirements for merging:
- [x] I have opened an issue or PR upstream on JuliaLang/julia: https://github.com/JuliaLang/julia/pull/49240/files
- [x] I have removed the `port-to-*` labels that don't apply.
- [x] I have opened a PR on raicode to test these changes: https://github.com/RelationalAI/raicode/pull/16306
