### PR TITLE
Backport: Move test of stackoverflow with close(::Channel) to stack_overflow.jl (#49702)

### DIFF
--- a/test/channels.jl
+++ b/test/channels.jl
@@ -633,20 +633,3 @@ end
         @test n_avail(c) == 0
     end
 end
-
-# Issue #49507: stackoverflow in type inference caused by close(::Channel, ::Exception)
-@testset "close(::Channel, ::StackOverflowError)" begin
-    ch = let result = Channel()
-        foo() = try
-            foo()
-        catch e;
-            close(result, e)
-        end
-
-        foo()  # This shouldn't fail with an internal stackoverflow error in inference.
-
-        result
-    end
-
-    @test (try take!(ch) catch e; e; end) isa StackOverflowError
-end


### PR DESCRIPTION
Backports PR https://github.com/JuliaLang/julia/pull/49702.

## PR Description

Original description:

Per @vtjnash's comment here:
https://github.com/JuliaLang/julia/pull/49508/files/bca5ac79d04fb2a95f3b9a7b7448fe5b478f950b#r1186161259

> the handling of this error is quite bad and sometimes ends up breaking
> the process (as I found out today trying to debug something completely
> unrelated)

This is a Tests-only PR


## Checklist

Requirements for merging:
- [x] I have opened an issue or PR upstream on JuliaLang/julia: https://github.com/JuliaLang/julia/pull/49702.
- [x] I have removed the `port-to-*` labels that don't apply.
- [x] I have opened a PR on raicode to test these changes: (Not needed, since this is test-only.)
