### PR TITLE
Make `jl_write_coverage_data` dllexported again

### DIFF
--- a/src/coverage.cpp
+++ b/src/coverage.cpp
@@ -192,7 +192,7 @@ static void write_lcov_data(logdata_t &logData, const std::string &outfile)
     outf.close();
 }
 
-extern "C" void jl_write_coverage_data(const char *output)
+extern "C" JL_DLLEXPORT void jl_write_coverage_data(const char *output)
 {
     if (output) {
         StringRef output_pattern(output);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1632,7 +1632,7 @@ JL_DLLEXPORT enum jl_memory_order jl_get_atomic_order_checked(jl_sym_t *order, c
 
 struct _jl_image_fptrs_t;
 
-void jl_write_coverage_data(const char*);
+JL_DLLEXPORT void jl_write_coverage_data(const char*);
 void jl_write_malloc_log(void);
 
 #if jl_has_builtin(__builtin_unreachable) || defined(_COMPILER_GCC_) || defined(_COMPILER_INTEL_)


### PR DESCRIPTION
<!---
PRs to RelationalAI/julia must be opened to the correct branch (see
https://github.com/RelationalAI/raicode/blob/master/nix/julia-version.json).
-->
## PR Description

Backports https://github.com/JuliaLang/julia/pull/52456
Fixes https://relationalai.atlassian.net/browse/RAI-19583

## Checklist

Requirements for merging:
- [x] I have opened an issue or PR upstream on JuliaLang/julia: https://github.com/JuliaLang/julia/issues/52452
- [x] I have removed the `port-to-*` labels that don't apply.
- [ ] I have opened a PR on raicode to test these changes: <link to raicode>
