### PR TITLE
 Add GitHub template and workflows needed on the default branch

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,4 @@
+# See https://github.com/actions/labeler
+port-to-master: '**'
+port-to-v1.10: '**'
+port-to-v1.9: '**'

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+<!---
+PRs to RelationalAI/julia must be opened to the correct branch (see
+https://github.com/RelationalAI/raicode/blob/master/nix/julia-version.json).
+-->
+## PR Description
+
+_What does this PR do?_
+
+## Checklist
+
+Requirements for merging:
+- [ ] I have opened an issue or PR upstream on JuliaLang/julia: <link to JuliaLang/julia>
+- [ ] I have removed the `port-to-*` labels that don't apply.
+- [ ] I have opened a PR on raicode to test these changes: <link to raicode>

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,17 @@
+# See https://github.com/actions/labeler
+name: "Pull Request Labeler"
+on:
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        dot: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,16 @@
+name: "Close stale PRs"
+on:
+  schedule:
+  - cron: "0 0 * * *" # every night at midnight
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v8
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Comment or remove stale label, or this PR will be closed in 5 days.'
+        days-before-stale: 30
+        days-before-close: 5
+        stale-pr-label: 'stale'

--- a/.github/workflows/update-upstream-branches.yml
+++ b/.github/workflows/update-upstream-branches.yml
@@ -1,0 +1,29 @@
+name: "Update upstream branches"
+on:
+  schedule:
+    - cron: "0 0 * * *" # every night at midnight
+  workflow_dispatch:
+
+jobs:
+  PullUpstream:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false  # run all jobs in the matrix even if one fails
+      matrix:
+        branch:
+          - "master"
+          - "backports-release-1.10"
+          - "backports-release-1.9"
+    steps:
+      - name: Checkout RAI/julia
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ matrix.branch }}
+      - name: Update ${{ matrix.branch }}
+        run: |
+          git config --global user.email "julia-engineering@relational.ai"
+          git config --global user.name "RAI CI (GitHub Action Automation)"
+
+          git remote add upstream https://github.com/JuliaLang/julia
+          git pull upstream ${{ matrix.branch }}
+          git push origin ${{ matrix.branch }}


### PR DESCRIPTION
Copied from the `v1.9.2+RAI` branch via `git checkout v1.9.2+RAI -- .github`
