### PR TITLE
--safe-crash-log-file flag

### DIFF
--- a/base/options.jl
+++ b/base/options.jl
@@ -57,6 +57,7 @@ struct JLOptions
     strip_ir::Int8
     permalloc_pkgimg::Int8
     heap_size_hint::UInt64
+    safe_crash_log_file::Ptr{UInt8}
 end
 
 # This runs early in the sysimage != is not defined yet

--- a/src/init.c
+++ b/src/init.c
@@ -825,7 +825,7 @@ JL_DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel)
 
 #if defined(_OS_LINUX_) && defined(_CPU_X86_64_)
     if (jl_options.safe_crash_log_file != NULL) {
-        jl_sig_fd = open(jl_options.safe_crash_log_file, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+        jl_sig_fd = open(jl_options.safe_crash_log_file, O_WRONLY | O_CREAT | O_APPEND, 0600);
         if (jl_sig_fd == -1) {
             jl_error("fatal error: could not open safe crash log file for writing");
         }

--- a/src/init.c
+++ b/src/init.c
@@ -823,6 +823,15 @@ JL_DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel)
     if (jl_options.handle_signals == JL_OPTIONS_HANDLE_SIGNALS_ON)
         jl_install_default_signal_handlers();
 
+#if defined(_OS_LINUX_) && defined(_CPU_X86_64_)
+    if (jl_options.safe_crash_log_file != NULL) {
+        jl_sig_fd = open(jl_options.safe_crash_log_file, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+        if (jl_sig_fd == -1) {
+            jl_error("fatal error: could not open safe crash log file for writing");
+        }
+    }
+#endif
+
     jl_gc_init();
 
     arraylist_new(&jl_linkage_blobs, 0);

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -678,6 +678,56 @@ JL_DLLEXPORT int jl_printf(uv_stream_t *s, const char *format, ...)
     return c;
 }
 
+STATIC_INLINE void print_error_msg_as_json(char *buf) JL_NOTSAFEPOINT
+{
+    // Our telemetry on SPCS expects a JSON object per line
+    // The following lines prepare the timestamp string and the JSON object
+    struct timeval tv;
+    struct tm* tm_info;
+    char timestamp_buffer[50];
+    // Get current time
+    gettimeofday(&tv, NULL);
+    tm_info = gmtime(&tv.tv_sec);
+    // Format time
+    int offset = strftime(timestamp_buffer, 25, "%Y-%m-%dT%H:%M:%S", tm_info);
+    // Append milliseconds
+    snprintf(timestamp_buffer + offset, 25, ".%03d", tv.tv_usec / 1000);
+    const char *json_preamble_p1 = "\n{\"level\":\"Error\", \"timestamp\":\"";
+    const char *json_preamble_p2 = "\", \"message\": \"";
+    const char *json_postamble = "\"}\n";
+    // Ignore write failures because there is nothing we can do
+    write(jl_sig_fd, json_preamble_p1, strlen(json_preamble_p1));
+    write(jl_sig_fd, timestamp_buffer, strlen(timestamp_buffer));
+    write(jl_sig_fd, json_preamble_p2, strlen(json_preamble_p2));
+    // JSON escape the input string
+    for(size_t i = 0; i < strlen(buf); i += 1) {
+        switch (buf[i]) {
+            case '"':
+                write(jl_sig_fd, "\\\"", 2);
+                break;
+            case '\b':
+                write(jl_sig_fd, "\\b", 2);
+                break;
+            case '\n':
+                write(jl_sig_fd, "\\n", 2);
+                break;
+            case '\r':
+                write(jl_sig_fd, "\\r", 2);
+                break;
+            case '\t':
+                write(jl_sig_fd, "\\t", 2);
+                break;
+            case '\\':
+                write(jl_sig_fd, "\\\\", 2);
+                break;
+            default:
+                write(jl_sig_fd, buf + i, 1);
+        }
+    }
+    write(jl_sig_fd, json_postamble, strlen(json_postamble));
+    fdatasync(jl_sig_fd);
+}
+
 JL_DLLEXPORT void jl_safe_printf(const char *fmt, ...)
 {
     static char buf[1000];
@@ -694,54 +744,8 @@ JL_DLLEXPORT void jl_safe_printf(const char *fmt, ...)
     va_end(args);
 
     buf[999] = '\0';
-    // Our telemetry on SPCS expects a JSON object per line
-    // The following lines prepare the timestamp string and the JSON object
-    struct timeval tv;
-    struct tm* tm_info;
-    char timestamp_buffer[50];
-    // Get current time
-    gettimeofday(&tv, NULL);
-    tm_info = gmtime(&tv.tv_sec);
-    // Format time
-    int offset = strftime(timestamp_buffer, 25, "%Y-%m-%dT%H:%M:%S", tm_info);
-    // Append milliseconds
-    snprintf(timestamp_buffer + offset, 25, ".%03d", tv.tv_usec / 1000);
-
-    const char *json_preamble_p1 = "\n{\"level\":\"Error\", \"timestamp\":\"";
-    const char *json_preamble_p2 = "\", \"message\": \"";
-    const char *json_postamble = "\"}\n";
     if (jl_inside_signal_handler() && jl_sig_fd != 0) {
-        // Ignore write failures because there is nothing we can do
-        write(jl_sig_fd, json_preamble_p1, strlen(json_preamble_p1));
-        write(jl_sig_fd, timestamp_buffer, strlen(timestamp_buffer));
-        write(jl_sig_fd, json_preamble_p2, strlen(json_preamble_p2));
-        // JSON escape the input string
-        for(size_t i = 0; i < strlen(buf); i += 1) {
-            switch (buf[i]) {
-                case '"':
-                    write(jl_sig_fd, "\\\"", 2);
-                    break;
-                case '\b':
-                    write(jl_sig_fd, "\\b", 2);
-                    break;
-                case '\n':
-                    write(jl_sig_fd, "\\n", 2);
-                    break;
-                case '\r':
-                    write(jl_sig_fd, "\\r", 2);
-                    break;
-                case '\t':
-                    write(jl_sig_fd, "\\t", 2);
-                    break;
-                case '\\':
-                    write(jl_sig_fd, "\\\\", 2);
-                    break;
-                default:
-                    write(jl_sig_fd, buf + i, 1);
-            }
-        }
-        write(jl_sig_fd, json_postamble, strlen(json_postamble));
-        fdatasync(jl_sig_fd);
+        print_error_msg_as_json(buf);
     }
     else {
         if (write(STDERR_FILENO, buf, strlen(buf)) < 0) {

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -708,7 +708,7 @@ JL_DLLEXPORT void jl_safe_printf(const char *fmt, ...)
     snprintf(timestamp_buffer + offset, 25, ".%03ld", tv.tv_usec / 1000);
 
     const char *json_preamble_p1 = "\n{\"level\":\"Error\", \"timestamp\":\"";
-    const char *json_preamble_p2 = ", \"message\": \"";
+    const char *json_preamble_p2 = "\", \"message\": \"";
     const char *json_postamble = "\"}\n";
     if (jl_inside_signal_handler() && jl_sig_fd != 0) {
         // Ignore write failures because there is nothing we can do

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -693,8 +693,15 @@ JL_DLLEXPORT void jl_safe_printf(const char *fmt, ...)
     va_end(args);
 
     buf[999] = '\0';
-    if (write(STDERR_FILENO, buf, strlen(buf)) < 0) {
-        // nothing we can do; ignore the failure
+    if (jl_inside_signal_handler() && jl_sig_fd != 0) {
+        if (write(jl_sig_fd, buf, strlen(buf)) < 0) {
+            // nothing we can do; ignore the failure
+        }
+    }
+    else {
+        if (write(STDERR_FILENO, buf, strlen(buf)) < 0) {
+            // nothing we can do; ignore the failure
+        }
     }
 #ifdef _OS_WINDOWS_
     SetLastError(last_error);

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -747,10 +747,8 @@ JL_DLLEXPORT void jl_safe_printf(const char *fmt, ...)
     if (jl_inside_signal_handler() && jl_sig_fd != 0) {
         print_error_msg_as_json(buf);
     }
-    else {
-        if (write(STDERR_FILENO, buf, strlen(buf)) < 0) {
-            // nothing we can do; ignore the failure
-        }
+    if (write(STDERR_FILENO, buf, strlen(buf)) < 0) {
+        // nothing we can do; ignore the failure
     }
 #ifdef _OS_WINDOWS_
     SetLastError(last_error);

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -90,6 +90,7 @@ JL_DLLEXPORT void jl_init_options(void)
                         0, // strip-ir
                         0, // permalloc_pkgimg
                         0, // heap-size-hint
+                        NULL, // safe_crash_log_file
     };
     jl_options_initialized = 1;
 }
@@ -258,7 +259,8 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
            opt_strip_ir,
            opt_heap_size_hint,
            opt_gc_threads,
-           opt_permalloc_pkgimg
+           opt_permalloc_pkgimg,
+           opt_safe_crash_log_file,
     };
     static const char* const shortopts = "+vhqH:e:E:L:J:C:it:p:O:g:";
     static const struct option longopts[] = {
@@ -320,6 +322,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
         { "strip-ir",        no_argument,       0, opt_strip_ir },
         { "permalloc-pkgimg",required_argument, 0, opt_permalloc_pkgimg },
         { "heap-size-hint",  required_argument, 0, opt_heap_size_hint },
+        { "safe-crash-log-file",   required_argument, 0, opt_safe_crash_log_file },
         { 0, 0, 0, 0 }
     };
 
@@ -849,6 +852,11 @@ restart_switch:
                 jl_options.permalloc_pkgimg = 0;
             else
                 jl_errorf("julia: invalid argument to --permalloc-pkgimg={yes|no} (%s)", optarg);
+            break;
+        case opt_safe_crash_log_file:
+            jl_options.safe_crash_log_file = strdup(optarg);
+            if (jl_options.safe_crash_log_file == NULL)
+                jl_error("julia: failed to allocate memory for --safe-crash-log-file");
             break;
         default:
             jl_errorf("julia: unhandled option -- %c\n"

--- a/src/jloptions.h
+++ b/src/jloptions.h
@@ -61,6 +61,7 @@ typedef struct {
     int8_t strip_ir;
     int8_t permalloc_pkgimg;
     uint64_t heap_size_hint;
+    const char *safe_crash_log_file;
 } jl_options_t;
 
 #endif

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -702,7 +702,7 @@ JL_CALLABLE(jl_f_opaque_closure_call);
 void jl_install_default_signal_handlers(void);
 void restore_signals(void);
 void jl_install_thread_signal_handler(jl_ptls_t ptls);
-extern size_t sig_stack_size;
+extern const size_t sig_stack_size;
 STATIC_INLINE int is_addr_on_sigstack(jl_ptls_t ptls, void *ptr)
 {
     // One guard page for signal_stack.

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -702,6 +702,29 @@ JL_CALLABLE(jl_f_opaque_closure_call);
 void jl_install_default_signal_handlers(void);
 void restore_signals(void);
 void jl_install_thread_signal_handler(jl_ptls_t ptls);
+extern void *signal_stack;
+extern size_t sig_stack_size;
+STATIC_INLINE int is_addr_on_sigstack(jl_ptls_t ptls, void *ptr)
+{
+    // One guard page for signal_stack.
+    return !((char*)ptr < (char*)ptls->signal_stack - jl_page_size ||
+             (char*)ptr > (char*)ptls->signal_stack + sig_stack_size);
+}
+STATIC_INLINE int jl_inside_signal_handler(void)
+{
+#if defined(_OS_LINUX_) && defined(_CPU_X86_64_)
+    // Read the stack pointer
+    size_t sp;
+    __asm__ __volatile__("movq %%rsp, %0" : "=r"(sp));
+    // Check if the stack pointer is within the signal stack
+    jl_ptls_t ptls = jl_current_task->ptls;
+    return is_addr_on_sigstack(ptls, (void*)sp);
+#else
+    return 0;
+#endif
+}
+// File-descriptor for safe logging on signal handling
+extern int jl_sig_fd;
 
 JL_DLLEXPORT jl_fptr_args_t jl_get_builtin_fptr(jl_value_t *b);
 

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -28,6 +28,10 @@ static const    uint64_t GIGA = 1000000000ULL;
 // Timers to take samples at intervals
 JL_DLLEXPORT void jl_profile_stop_timer(void);
 JL_DLLEXPORT int jl_profile_start_timer(void);
+// Signal stack
+void *signal_stack = NULL;
+// File-descriptor for safe logging on signal handling
+int jl_sig_fd;
 
 ///////////////////////
 // Utility functions //

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -38,7 +38,7 @@
 // 8M signal stack, same as default stack size and enough
 // for reasonable finalizers.
 // Should also be enough for parallel GC when we have it =)
-size_t sig_stack_size = (8 * 1024 * 1024);
+const size_t sig_stack_size = (8 * 1024 * 1024);
 
 #include "julia_assert.h"
 

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -38,7 +38,7 @@
 // 8M signal stack, same as default stack size and enough
 // for reasonable finalizers.
 // Should also be enough for parallel GC when we have it =)
-#define sig_stack_size (8 * 1024 * 1024)
+size_t sig_stack_size = (8 * 1024 * 1024);
 
 #include "julia_assert.h"
 
@@ -89,13 +89,6 @@ static inline __attribute__((unused)) uintptr_t jl_get_rsp_from_ctx(const void *
     // TODO Add support for PowerPC(64)?
     return 0;
 #endif
-}
-
-static int is_addr_on_sigstack(jl_ptls_t ptls, void *ptr)
-{
-    // One guard page for signal_stack.
-    return !((char*)ptr < (char*)ptls->signal_stack - jl_page_size ||
-             (char*)ptr > (char*)ptls->signal_stack + sig_stack_size);
 }
 
 // Modify signal context `_ctx` so that `fptr` will execute when the signal
@@ -640,7 +633,7 @@ static void *alloc_sigstack(size_t *ssize)
 void jl_install_thread_signal_handler(jl_ptls_t ptls)
 {
     size_t ssize = sig_stack_size;
-    void *signal_stack = alloc_sigstack(&ssize);
+    signal_stack = alloc_sigstack(&ssize);
     ptls->signal_stack = signal_stack;
     stack_t ss;
     ss.ss_flags = 0;

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -4,7 +4,7 @@
 // Note that this file is `#include`d by "signal-handling.c"
 #include <mmsystem.h> // hidden by LEAN_AND_MEAN
 
-#define sig_stack_size 131072 // 128k reserved for SEGV handling
+size_t sig_stack_size = 131072; // 128k reserved for SEGV handling
 
 // Copied from MINGW_FLOAT_H which may not be found due to a collision with the builtin gcc float.h
 // eventually we can probably integrate this into OpenLibm.

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -4,7 +4,7 @@
 // Note that this file is `#include`d by "signal-handling.c"
 #include <mmsystem.h> // hidden by LEAN_AND_MEAN
 
-size_t sig_stack_size = 131072; // 128k reserved for SEGV handling
+const size_t sig_stack_size = 131072; // 128k reserved for SEGV handling
 
 // Copied from MINGW_FLOAT_H which may not be found due to a collision with the builtin gcc float.h
 // eventually we can probably integrate this into OpenLibm.


### PR DESCRIPTION
## PR Description

Creates a `--safe-crash-log-file` that is used to redirect crash logs created while we were running the signal handler.

For now it's only x86_64 Linux but shouldn't be that hard to port it to MacOS.

Example usage:

```
./julia --safe-crash-log-file=/tmp/foobar.txt -e "p = Ptr{Any}(C_NULL); b = unsafe_load(p, 0)"
```

Which leads to:

```
cat /tmp/foobar.txt 

[83691] signal (11.1): Segmentation fault
in expression starting at none:1
signal (11) thread (1) unsafe_load at ./pointer.jl:119
signal (11) thread (1) unknown function (ip: 0x7f477566a17f)
signal (11) thread (1) _jl_invoke at /home/ubuntu/julia-RAI/src/gf.c:2895 [inlined]
signal (11) thread (1) ijl_apply_generic at /home/ubuntu/julia-RAI/src/gf.c:3077
signal (11) thread (1) jl_apply at /home/ubuntu/julia-RAI/src/julia.h:1982 [inlined]
signal (11) thread (1) do_call at /home/ubuntu/julia-RAI/src/interpreter.c:126
signal (11) thread (1) eval_value at /home/ubuntu/julia-RAI/src/interpreter.c:223
signal (11) thread (1) eval_stmt_value at /home/ubuntu/julia-RAI/src/interpreter.c:174 [inlined]
signal (11) thread (1) eval_body at /home/ubuntu/julia-RAI/src/interpreter.c:617
signal (11) thread (1) jl_interpret_toplevel_thunk at /home/ubuntu/julia-RAI/src/interpreter.c:775
signal (11) thread (1) jl_toplevel_eval_flex at /home/ubuntu/julia-RAI/src/toplevel.c:934
signal (11) thread (1) jl_toplevel_eval_flex at /home/ubuntu/julia-RAI/src/toplevel.c:877
signal (11) thread (1) jl_toplevel_eval_flex at /home/ubuntu/julia-RAI/src/toplevel.c:877
signal (11) thread (1) ijl_toplevel_eval_in at /home/ubuntu/julia-RAI/src/toplevel.c:985
signal (11) thread (1) eval at ./boot.jl:385 [inlined]
signal (11) thread (1) exec_options at ./client.jl:291
signal (11) thread (1) _start at ./client.jl:552
signal (11) thread (1) jfptr__start_83344 at /home/ubuntu/julia-RAI/usr/lib/julia/sys.so (unknown line)
signal (11) thread (1) _jl_invoke at /home/ubuntu/julia-RAI/src/gf.c:2895 [inlined]
signal (11) thread (1) ijl_apply_generic at /home/ubuntu/julia-RAI/src/gf.c:3077
signal (11) thread (1) jl_apply at /home/ubuntu/julia-RAI/src/julia.h:1982 [inlined]
signal (11) thread (1) true_main at /home/ubuntu/julia-RAI/src/jlapi.c:582
signal (11) thread (1) jl_repl_entrypoint at /home/ubuntu/julia-RAI/src/jlapi.c:731
signal (11) thread (1) main at /home/ubuntu/julia-RAI/cli/loader_exe.c:58
signal (11) thread (1) __libc_start_main at /lib/x86_64-linux-gnu/libc.so.6 (unknown line)
signal (11) thread (1) _start at ./julia (unknown line)
Allocations: 2908 (Pool: 2898; Big: 10); GC: 0
```

## Checklist

Requirements for merging:
- [ ] I have opened an issue or PR upstream on JuliaLang/julia: NIL
- [ ] I have removed the `port-to-*` labels that don't apply.
- [ ] I have opened a PR on raicode to test these changes: NIL
