### PR TITLE
create phantom task for GC threads (#53815) & fix ordering in jl_safe_printf

### DIFF
--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -744,7 +744,10 @@ JL_DLLEXPORT void jl_safe_printf(const char *fmt, ...)
     va_end(args);
 
     buf[999] = '\0';
-    if (jl_inside_signal_handler() && jl_sig_fd != 0) {
+    // order is important here: we want to ensure that the threading infra
+    // has been initialized before we start trying to print to the
+    // safe crash log file
+    if (jl_sig_fd != 0 && jl_inside_signal_handler()) {
         print_error_msg_as_json(buf);
     }
     if (write(STDERR_FILENO, buf, strlen(buf)) < 0) {

--- a/src/partr.c
+++ b/src/partr.c
@@ -125,7 +125,11 @@ void jl_parallel_gc_threadfun(void *arg)
 
     // initialize this thread (set tid and create heap)
     jl_ptls_t ptls = jl_init_threadtls(targ->tid);
-
+    void *stack_lo, *stack_hi;
+    jl_init_stack_limits(0, &stack_lo, &stack_hi);
+    // warning: this changes `jl_current_task`, so be careful not to call that from this function
+    jl_task_t *ct = jl_init_root_task(ptls, stack_lo, stack_hi);
+    JL_GC_PROMISE_ROOTED(ct);
     // wait for all threads
     jl_gc_state_set(ptls, JL_GC_STATE_WAITING, 0);
     uv_barrier_wait(targ->barrier);
@@ -156,7 +160,11 @@ void jl_concurrent_gc_threadfun(void *arg)
 
     // initialize this thread (set tid and create heap)
     jl_ptls_t ptls = jl_init_threadtls(targ->tid);
-
+    void *stack_lo, *stack_hi;
+    jl_init_stack_limits(0, &stack_lo, &stack_hi);
+    // warning: this changes `jl_current_task`, so be careful not to call that from this function
+    jl_task_t *ct = jl_init_root_task(ptls, stack_lo, stack_hi);
+    JL_GC_PROMISE_ROOTED(ct);
     // wait for all threads
     jl_gc_state_set(ptls, JL_GC_STATE_WAITING, 0);
     uv_barrier_wait(targ->barrier);

--- a/src/task.c
+++ b/src/task.c
@@ -1685,6 +1685,7 @@ jl_task_t *jl_init_root_task(jl_ptls_t ptls, void *stack_lo, void *stack_hi)
     JL_GC_PROMISE_ROOTED(ct);
     jl_set_pgcstack(&ct->gcstack);
     assert(jl_current_task == ct);
+    assert(jl_current_task->ptls == ptls);
 
 #ifdef _COMPILER_TSAN_ENABLED_
     ct->ctx.tsan_state = __tsan_get_current_fiber();


### PR DESCRIPTION
## PR Description

A common idiom used throughout the codebase is to get a pointer to thread-local-state through `jl_current_task->ptls`.

Create a phantom task for GC threads so that we can make use of this idiom when running in the GC threads as well.

Idea originally suggested by @vchuravy, bugs are mine.

## Checklist

Requirements for merging:
- [x] I have opened an issue or PR upstream on JuliaLang/julia: https://github.com/JuliaLang/julia/pull/53815
- [x] I have removed the `port-to-*` labels that don't apply.
- [x] I have opened a PR on raicode to test these changes: https://github.com/RelationalAI/raicode/pull/18669.
