### PR TITLE
Correct GC bug (usage of `not_freed_enough`)

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -3643,7 +3643,7 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection)
 
     if (collection == JL_GC_AUTO) {
         //If we aren't freeing enough or are seeing lots and lots of pointers let it increase faster
-        if (!not_freed_enough || large_frontier) {
+        if (not_freed_enough || large_frontier) {
             int64_t tot = 2 * (live_bytes + gc_num.since_sweep) / 3;
             if (gc_num.interval > tot) {
                 gc_num.interval = tot;


### PR DESCRIPTION
<!---
PRs to RelationalAI/julia must be opened to the correct branch (see
https://github.com/RelationalAI/raicode/blob/master/nix/julia-version.json).
-->
## PR Description

Fix a typo-bug in the GC.

## Checklist

Requirements for merging:
- [X] I have opened an issue or PR upstream on JuliaLang/julia: https://github.com/JuliaLang/julia/issues/53325
- [x] I have removed the `port-to-*` labels that don't apply.
- [X] I have opened a PR on raicode to test these changes: https://github.com/RelationalAI/raicode/pull/18823.
