### PR TITLE
Stop updating upstream 1.9 branch

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,3 @@
 # See https://github.com/actions/labeler
 port-to-master: '**'
 port-to-v1.10: '**'
-port-to-v1.9: '**'

--- a/.github/workflows/update-upstream-branches.yml
+++ b/.github/workflows/update-upstream-branches.yml
@@ -13,7 +13,6 @@ jobs:
         branch:
           - "master"
           - "backports-release-1.10"
-          - "backports-release-1.9"
     steps:
       - name: Checkout RAI/julia
         uses: actions/checkout@v3


### PR DESCRIPTION
<!---
PRs to RelationalAI/julia must be opened to the correct branch (see
https://github.com/RelationalAI/raicode/blob/master/nix/julia-version.json).
-->
## PR Description

Simplifies our automations now we're not using v1.9
