### PR TITLE
function to query page size

### DIFF
--- a/src/gc-pages.c
+++ b/src/gc-pages.c
@@ -9,6 +9,11 @@
 extern "C" {
 #endif
 
+JL_DLLEXPORT uint64_t jl_get_pg_size(void)
+{
+    return GC_PAGE_SZ;
+}
+
 // Try to allocate memory in chunks to permit faster allocation
 // and improve memory locality of the pools
 #ifdef _P64


### PR DESCRIPTION
## PR Description

Exposes a function to get GC page size. Requested [here](https://relationalai.slack.com/archives/C068ANEBS04/p1713365676930839?thread_ts=1713365265.705269&cid=C068ANEBS04).

Example usage:

```Julia
julia> @ccall jl_get_pg_size()::UInt64
0x0000000000004000
```

## Checklist

Requirements for merging:
- [x] I have opened an issue or PR upstream on JuliaLang/julia: https://github.com/JuliaLang/julia/pull/54115
- [x] I have removed the `port-to-*` labels that don't apply.
- [x] I have opened a PR on raicode to test these changes: https://github.com/RelationalAI/raicode/pull/19081.
