### PR TITLE
RAI: do not prepend thread ID to backtraces from signal handler context

### DIFF
--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -949,7 +949,7 @@ static void *signal_listener(void *arg)
             jl_safe_printf("\nsignal (%d): %s\n", sig, strsignal(sig));
             size_t i;
             for (i = 0; i < bt_size; i += jl_bt_entry_size(bt_data + i)) {
-                jl_print_bt_entry_codeloc(-1, bt_data + i);
+                jl_print_bt_entry_codeloc(sig, bt_data + i);
             }
         }
     }

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -660,11 +660,14 @@ void jl_print_native_codeloc(char *pre_str, uintptr_t ip) JL_NOTSAFEPOINT
 void jl_print_bt_entry_codeloc(int sig, jl_bt_element_t *bt_entry) JL_NOTSAFEPOINT
 {
     char sig_str[32], pre_str[64];
-    sig_str[0] = '\0';
+    sig_str[0] = pre_str[0] = '\0';
     if (sig != -1) {
         snprintf(sig_str, 32, "signal (%d) ", sig);
     }
-    snprintf(pre_str, 64, "%sthread (%d) ", sig_str, jl_threadid() + 1);
+    // do not call jl_threadid if there's no current task
+    if (jl_get_current_task()) {
+        snprintf(pre_str, 64, "%sthread (%d) ", sig_str, jl_threadid() + 1);
+    }
 
     if (jl_bt_is_native(bt_entry)) {
         jl_print_native_codeloc(pre_str, bt_entry[0].uintptr);
@@ -1120,7 +1123,11 @@ static void jl_rec_backtrace(jl_task_t *t) JL_NOTSAFEPOINT
 JL_DLLEXPORT void jl_gdblookup(void* ip)
 {
     char pre_str[64];
-    snprintf(pre_str, 64, "thread (%d) ", jl_threadid() + 1);
+    pre_str[0] = '\0';
+    // do not call jl_threadid if there's no current task
+    if (jl_get_current_task()) {
+        snprintf(pre_str, 64, "thread (%d) ", jl_threadid() + 1);
+    }
     jl_print_native_codeloc(pre_str, (uintptr_t)ip);
 }
 
@@ -1165,7 +1172,11 @@ JL_DLLEXPORT void jl_print_task_backtraces(int show_done) JL_NOTSAFEPOINT
 {
     size_t nthreads = jl_atomic_load_acquire(&jl_n_threads);
     jl_ptls_t *allstates = jl_atomic_load_relaxed(&jl_all_tls_states);
-    int ctid = jl_threadid() + 1;
+    int ctid = -1;
+    // do not call jl_threadid if there's no current task
+    if (jl_get_current_task()) {
+        ctid = jl_threadid() + 1;
+    }
     jl_safe_printf("thread (%d) ++++ Task backtraces\n", ctid);
     for (size_t i = 0; i < nthreads; i++) {
         // skip GC threads since they don't have tasks


### PR DESCRIPTION
<!---
PRs to RelationalAI/julia must be opened to the correct branch (see
https://github.com/RelationalAI/raicode/blob/master/nix/julia-version.json).
-->
## PR Description

`Ctrl+T` sends a `SIGINFO` (on Mac, `SIGUSR1` on Linux) to Julia which triggers a backtrace. RAI Julia prepends `[signal (X)] thread (Y)` to backtraces. But in signal handler context, there is no "current task" from which to get the thread ID.

This PR fixes the problem by checking to see if we're in signal handler context before calling `jl_threadid()`.

## Checklist

Requirements for merging:
- [ ] I have opened an issue or PR upstream on JuliaLang/julia: N/A--this fixes a RAI patch
- [ ] I have removed the `port-to-*` labels that don't apply.
- [X] I have opened a PR on raicode to test these changes: https://github.com/RelationalAI/raicode/pull/19065
