### PR TITLE
RAI: Change optimization aggressiveness for `-O1` from `None` to `Less`

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -677,7 +677,8 @@ CodeGenOpt::Level CodeGenOptLevelFor(int optlevel)
 #ifdef DISABLE_OPT
     return CodeGenOpt::None;
 #else
-    return optlevel < 2 ? CodeGenOpt::None :
+    return optlevel == 0 ? CodeGenOpt::None :
+        optlevel == 1 ? CodeGenOpt::Less :
         optlevel == 2 ? CodeGenOpt::Default :
         CodeGenOpt::Aggressive;
 #endif


### PR DESCRIPTION
<!---
PRs to RelationalAI/julia must be opened to the correct branch (see
https://github.com/RelationalAI/raicode/blob/master/nix/julia-version.json).
-->
## PR Description

As part of https://relationalai.atlassian.net/browse/RAI-24337.

This change is also going to be merged upstream as part of another PR. See https://github.com/JuliaLang/julia/pull/54140/commits/346972a527147f1f8afdee0cb9518c79cbfe0757.

## Checklist

Requirements for merging:
- [X] ~~I have opened an issue or~~ PR upstream on JuliaLang/julia: https://github.com/JuliaLang/julia/pull/54140
- [X] I have removed the `port-to-*` labels that don't apply.
- [X] I have opened a PR on raicode to test these changes: https://github.com/RelationalAI/raicode/pull/18813
