### PR TITLE
Fix `gc_first_tid`

### DIFF
--- a/src/threading.c
+++ b/src/threading.c
@@ -709,7 +709,7 @@ void jl_init_threading(void)
     jl_atomic_store_release(&jl_all_tls_states, (jl_ptls_t*)calloc(jl_all_tls_states_size, sizeof(jl_ptls_t)));
     jl_atomic_store_release(&jl_n_threads, jl_all_tls_states_size);
     jl_n_gcthreads = ngcthreads;
-    gc_first_tid = nthreads;
+    gc_first_tid = nthreads + nthreadsi;
 }
 
 static uv_barrier_t thread_init_done;


### PR DESCRIPTION
## PR Description

The first GC thread's TID was set to the first thread after the default threadpool. When there are interactive threads, this is set incorrectly.

## Checklist

Requirements for merging:
- [ ] I have opened an issue or PR upstream on JuliaLang/julia: <link to JuliaLang/julia>
- [ ] I have removed the `port-to-*` labels that don't apply.
- [ ] I have opened a PR on raicode to test these changes: <link to raicode>
