### PR TITLE
Backport fix for another segfault

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -112,7 +112,7 @@ static int8_t jl_cachearg_offset(jl_methtable_t *mt)
 
 static uint_t speccache_hash(size_t idx, jl_svec_t *data)
 {
-    jl_method_instance_t *ml = (jl_method_instance_t*)jl_svecref(data, idx);
+    jl_method_instance_t *ml = (jl_method_instance_t*)jl_svecref(data, idx); // This must always happen inside the lock
     jl_value_t *sig = ml->specTypes;
     if (jl_is_unionall(sig))
         sig = jl_unwrap_unionall(sig);
@@ -121,6 +121,8 @@ static uint_t speccache_hash(size_t idx, jl_svec_t *data)
 
 static int speccache_eq(size_t idx, const void *ty, jl_svec_t *data, uint_t hv)
 {
+    if (idx >= jl_svec_len(data))
+        return 0; // We got a OOB access, probably due to a data race
     jl_method_instance_t *ml = (jl_method_instance_t*)jl_svecref(data, idx);
     jl_value_t *sig = ml->specTypes;
     if (ty == sig)


### PR DESCRIPTION
## PR Description

[This segfault](https://relationalai.slack.com/archives/CCXL42PRV/p1718659586975329). Fix is similar to https://github.com/RelationalAI/julia/pull/158.

Upstream fix is https://github.com/JuliaLang/julia/pull/54840.

## Checklist

Requirements for merging:
- [X] I have opened an issue or PR upstream on JuliaLang/julia: https://github.com/JuliaLang/julia/pull/54840
- [X] I have removed the `port-to-*` labels that don't apply.
- [ ] I have opened a PR on raicode to test these changes: <link to raicode>
