### PR TITLE
guard list of big objects by a lock

### DIFF
--- a/src/gc.h
+++ b/src/gc.h
@@ -122,12 +122,13 @@ JL_EXTENSION typedef struct _bigval_t {
     struct _bigval_t *next;
     struct _bigval_t **prev; // pointer to the next field of the prev entry
     size_t sz;
+    jl_ptls_t owner_thread_ptls;
 #ifdef _P64 // Add padding so that the value is 64-byte aligned
-    // (8 pointers of 8 bytes each) - (4 other pointers in struct)
-    void *_padding[8 - 4];
+    // (8 pointers of 8 bytes each) - (5 other pointers in struct)
+    void *_padding[8 - 5];
 #else
-    // (16 pointers of 4 bytes each) - (4 other pointers in struct)
-    void *_padding[16 - 4];
+    // (16 pointers of 4 bytes each) - (5 other pointers in struct)
+    void *_padding[16 - 5];
 #endif
     //struct jl_taggedvalue_t <>;
     union {

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -151,6 +151,7 @@ typedef struct {
     struct _mallocarray_t *mafreelist;
 
     // variables for tracking big objects
+    jl_mutex_t big_objects_lock;
     struct _bigval_t *big_objects;
 
     // variables for tracking "remembered set"


### PR DESCRIPTION
## PR Description

Alternative to https://github.com/RelationalAI/julia/pull/160 which doesn't allocate a new string, but rather guards all relevant list accesses by a mutex.

## Checklist

Requirements for merging:
- [x] I have opened an issue or PR upstream on JuliaLang/julia: N/A.
- [ ] I have removed the `port-to-*` labels that don't apply.
- [x] I have opened a PR on raicode to test these changes: https://github.com/RelationalAI/raicode/pull/20106.
