### PR TITLE
cap live_bytes to zero in a few places where GC intervals are computed

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -8,6 +8,7 @@
 #ifdef __GLIBC__
 #include <malloc.h> // for malloc_trim
 #endif
+#include <math.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -3690,7 +3691,12 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection)
                 gc_num.interval = half;
         }
         // But never go below default
-        if (gc_num.interval < default_collect_interval) gc_num.interval = default_collect_interval;
+        if (gc_num.interval < default_collect_interval)
+            gc_num.interval = default_collect_interval;
+        // And never go above the upper bound
+        const int64_t interval_upper_bound = (int64_t)((double)max_total_memory / log2((double)max_total_memory));
+        if (gc_num.interval > interval_upper_bound)
+            gc_num.interval = interval_upper_bound;
     }
 
     if (gc_num.interval + live_bytes_for_interval_computation > max_total_memory) {


### PR DESCRIPTION
## PR Description

Caps live_bytes to 0 when computing GC intervals.

## Checklist

Requirements for merging:
- [x] I have opened an issue or PR upstream on JuliaLang/julia: N/A (patch to our fork).
- [x] I have removed the `port-to-*` labels that don't apply.
- [x] I have opened a PR on raicode to test these changes: https://github.com/RelationalAI/raicode/pull/20626.
