### PR TITLE
dont reset maxsize in jl_array_to_string

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -479,10 +479,8 @@ JL_DLLEXPORT jl_value_t *jl_array_to_string(jl_array_t *a)
             return o;
         }
     }
-    jl_gc_count_freed(jl_array_nbytes(a));
     a->nrows = 0;
     a->length = 0;
-    a->maxsize = 0;
     return jl_pchar_to_string((const char*)jl_array_data(a), len);
 }
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -1116,13 +1116,6 @@ void jl_gc_count_allocd(size_t sz) JL_NOTSAFEPOINT
         jl_atomic_load_relaxed(&ptls->gc_tls.gc_num.allocd) + sz);
 }
 
-void jl_gc_count_freed(size_t sz) JL_NOTSAFEPOINT
-{
-    jl_ptls_t ptls = jl_current_task->ptls;
-    jl_atomic_store_relaxed(&ptls->gc_tls.gc_num.freed,
-        jl_atomic_load_relaxed(&ptls->gc_tls.gc_num.freed) + sz);
-}
-
 static void combine_thread_gc_counts(jl_gc_num_t *dest) JL_NOTSAFEPOINT
 {
     int gc_n_threads;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -600,7 +600,6 @@ JL_DLLEXPORT int64_t jl_gc_sync_total_bytes(int64_t offset) JL_NOTSAFEPOINT;
 void jl_gc_track_malloced_array(jl_ptls_t ptls, jl_array_t *a) JL_NOTSAFEPOINT;
 size_t jl_array_nbytes(jl_array_t *a) JL_NOTSAFEPOINT;
 void jl_gc_count_allocd(size_t sz) JL_NOTSAFEPOINT;
-void jl_gc_count_freed(size_t sz) JL_NOTSAFEPOINT;
 void jl_gc_run_all_finalizers(jl_task_t *ct);
 void jl_release_task_stack(jl_ptls_t ptls, jl_task_t *task);
 void jl_gc_add_finalizer_(jl_ptls_t ptls, void *v, void *f) JL_NOTSAFEPOINT;


### PR DESCRIPTION
## PR Description

Test whether this fixes the negative GC live bytes issue.

## Checklist

Requirements for merging:
- [ ] I have opened an issue or PR upstream on JuliaLang/julia: <link to JuliaLang/julia>
- [ ] I have removed the `port-to-*` labels that don't apply.
- [x] I have opened a PR on raicode to test these changes: https://github.com/RelationalAI/raicode/pull/20663
