### PR TITLE
simple dynamic race detector for jl_array_to_string

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -855,6 +855,8 @@ JL_DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel)
 
 void jl_init_heartbeat(void);
 
+extern uv_mutex_t array_to_string_print_lock;
+
 static NOINLINE void _finish_julia_init(JL_IMAGE_SEARCH rel, jl_ptls_t ptls, jl_task_t *ct)
 {
     JL_TIMING(JULIA_INIT, JULIA_INIT);
@@ -901,6 +903,8 @@ static NOINLINE void _finish_julia_init(JL_IMAGE_SEARCH rel, jl_ptls_t ptls, jl_
     jl_start_threads();
     jl_start_gc_threads();
     uv_barrier_wait(&thread_init_done);
+
+    uv_mutex_init(&array_to_string_print_lock);
 
     jl_init_heartbeat();
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -95,7 +95,11 @@ typedef struct _jl_value_t jl_value_t;
 struct _jl_taggedvalue_bits {
     uintptr_t gc:2;
     uintptr_t in_image:1;
-    uintptr_t unused:1;
+    // Bit to indicate whether a call to `jl_array_to_string` is in-flight
+    // Mostly used to implement a poor-man's dynamic race detector.
+    // See usage in `jl_array_to_string`.
+#define ARRAY_TO_STRING_IN_FLIGHT_BIT_OFFSET (3)
+    uintptr_t array_to_string_in_flight:1;
 #ifdef _P64
     uintptr_t tag:60;
 #else
@@ -2228,6 +2232,7 @@ JL_DLLEXPORT size_t jl_static_show(JL_STREAM *out, jl_value_t *v) JL_NOTSAFEPOIN
 JL_DLLEXPORT size_t jl_static_show_func_sig(JL_STREAM *s, jl_value_t *type) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_print_backtrace(void) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jlbacktrace(void) JL_NOTSAFEPOINT; // deprecated
+JL_DLLEXPORT void jlbacktracet(jl_task_t *t) JL_NOTSAFEPOINT;
 // Mainly for debugging, use `void*` so that no type cast is needed in C++.
 JL_DLLEXPORT void jl_(void *jl_value) JL_NOTSAFEPOINT;
 


### PR DESCRIPTION
## PR Description

Simple dynamic race detector for `jl_array_to_string`. Here is a quick example:

```Julia
julia-RAI % ./julia -t8
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.10.2+RAI (2024-08-14)
 _/ |\__'_|_|_|\__'_|  |  v1.10.2+RAI/ec21f11718 (fork: 397 commits, 414 days)
|__/                   |

julia> a = UInt8['b' for _ in 1:1_000]
1000-element Vector{UInt8}:
 0x62
 0x62
 0x62
 0x62
 0x62
 0x62
 0x62
 0x62
 0x62
 0x62
 0x62
    ⋮
 0x62
 0x62
 0x62
 0x62
 0x62
 0x62
 0x62
 0x62
 0x62
 0x62

julia> Threads.@threads for _ in 1:1000
           String(a)
       end
ERROR: racy conversion of array to string... Setting in-flight bit
ERROR: racy conversion of array to string... Resetting in-flight bit
ERROR: racy conversion of array to string... Setting in-flight bit
ERROR: racy conversion of array to string... Resetting in-flight bit
ERROR: racy conversion of array to string... Setting in-flight bit
ERROR: racy conversion of array to string... Resetting in-flight biERROR: racy conversion of array to string... Resetting in-flight bit
ERROR: racy conversion of array to string... Resetting in-flight bit
```

## Checklist

Requirements for merging:
- [ ] I have opened an issue or PR upstream on JuliaLang/julia: <link to JuliaLang/julia>
- [ ] I have removed the `port-to-*` labels that don't apply.
- [ ] I have opened a PR on raicode to test these changes: <link to raicode>
