### PR TITLE
WIP: all task (wall-clock) profiler

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -206,6 +206,13 @@ JL_DLLEXPORT void jl_unlock_profile_wr(void) JL_NOTSAFEPOINT JL_NOTSAFEPOINT_LEA
 int jl_lock_stackwalk(void) JL_NOTSAFEPOINT JL_NOTSAFEPOINT_ENTER;
 void jl_unlock_stackwalk(int lockret) JL_NOTSAFEPOINT JL_NOTSAFEPOINT_LEAVE;
 
+void jl_rec_backtrace(jl_task_t *t) JL_NOTSAFEPOINT;
+extern volatile struct _jl_bt_element_t *bt_data_prof;
+extern volatile size_t bt_size_max;
+extern volatile size_t bt_size_cur;
+extern volatile int running;
+extern volatile int profile_all_tasks;
+
 // number of cycles since power-on
 static inline uint64_t cycleclock(void) JL_NOTSAFEPOINT
 {

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -23,7 +23,7 @@ volatile jl_bt_element_t *bt_data_prof = NULL;
 volatile size_t bt_size_max = 0;
 volatile size_t bt_size_cur = 0;
 static volatile uint64_t nsecprof = 0;
-volatile int profile_running = 0;
+volatile int running = 0;
 volatile int profile_all_tasks = 0;
 static const    uint64_t GIGA = 1000000000ULL;
 // Timers to take samples at intervals

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -19,12 +19,12 @@ extern "C" {
 
 // Profiler control variables
 // Note: these "static" variables are also used in "signals-*.c"
-static volatile jl_bt_element_t *bt_data_prof = NULL;
-static volatile size_t bt_size_max = 0;
-static volatile size_t bt_size_cur = 0;
+volatile jl_bt_element_t *bt_data_prof = NULL;
+volatile size_t bt_size_max = 0;
+volatile size_t bt_size_cur = 0;
 static volatile uint64_t nsecprof = 0;
-static volatile int running = 0;
-static volatile int profile_all_tasks = 0;
+volatile int profile_running = 0;
+volatile int profile_all_tasks = 0;
 static const    uint64_t GIGA = 1000000000ULL;
 // Timers to take samples at intervals
 JL_DLLEXPORT void jl_profile_stop_timer(void);

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -24,10 +24,11 @@ static volatile size_t bt_size_max = 0;
 static volatile size_t bt_size_cur = 0;
 static volatile uint64_t nsecprof = 0;
 static volatile int running = 0;
+static volatile int profile_all_tasks = 0;
 static const    uint64_t GIGA = 1000000000ULL;
 // Timers to take samples at intervals
 JL_DLLEXPORT void jl_profile_stop_timer(void);
-JL_DLLEXPORT int jl_profile_start_timer(void);
+JL_DLLEXPORT int jl_profile_start_timer(uint8_t);
 // File-descriptor for safe logging on signal handling
 int jl_sig_fd;
 

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -710,7 +710,7 @@ void *mach_profile_listener(void *arg)
     }
 }
 
-JL_DLLEXPORT int jl_profile_start_timer(void)
+JL_DLLEXPORT int jl_profile_start_timer(uint8_t all_tasks)
 {
     kern_return_t ret;
     if (!profile_started) {
@@ -740,6 +740,7 @@ JL_DLLEXPORT int jl_profile_start_timer(void)
     timerprof.tv_nsec = nsecprof%GIGA;
 
     running = 1;
+    profile_all_tasks = all_tasks;
     // ensure the alarm is running
     ret = clock_alarm(clk, TIME_RELATIVE, timerprof, profile_port);
     HANDLE_MACH_ERROR("clock_alarm", ret);
@@ -750,4 +751,5 @@ JL_DLLEXPORT int jl_profile_start_timer(void)
 JL_DLLEXPORT void jl_profile_stop_timer(void)
 {
     running = 0;
+    profile_all_tasks = 0;
 }

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -621,84 +621,18 @@ void *mach_profile_listener(void *arg)
         // (so that thread zero gets notified last)
         int keymgr_locked = jl_lock_profile_mach(0);
 
-        int nthreads = jl_atomic_load_acquire(&jl_n_threads);
-        int *randperm = profile_get_randperm(nthreads);
-        for (int idx = nthreads; idx-- > 0; ) {
-            // Stop the threads in the random or reverse round-robin order.
-            int i = randperm[idx];
-            // if there is no space left, break early
-            if (jl_profile_is_buffer_full()) {
-                jl_profile_stop_timer();
-                break;
+        if profile_all_tasks {
+            // t = select_task()
+            // jl_profile_task()
+        }
+        else {
+            int nthreads = jl_atomic_load_acquire(&jl_n_threads);
+            int *randperm = profile_get_randperm(nthreads);
+            for (int idx = nthreads; idx-- > 0; ) {
+                // Stop the threads in random order.
+                int i = randperm[idx];
+                jl_profile_thread(i);
             }
-
-            if (_dyld_dlopen_atfork_prepare != NULL && _dyld_dlopen_atfork_parent != NULL)
-                _dyld_dlopen_atfork_prepare();
-            if (_dyld_atfork_prepare != NULL && _dyld_atfork_parent != NULL)
-                _dyld_atfork_prepare(); // briefly acquire the dlsym lock
-            host_thread_state_t state;
-            int valid_thread = jl_thread_suspend_and_get_state2(i, &state);
-            unw_context_t *uc = (unw_context_t*)&state;
-            if (_dyld_atfork_prepare != NULL && _dyld_atfork_parent != NULL)
-                _dyld_atfork_parent(); // quickly release the dlsym lock
-            if (_dyld_dlopen_atfork_prepare != NULL && _dyld_dlopen_atfork_parent != NULL)
-                _dyld_dlopen_atfork_parent();
-            if (!valid_thread)
-                continue;
-            if (running) {
-#ifdef LLVMLIBUNWIND
-                /*
-                 *  Unfortunately compact unwind info is incorrectly generated for quite a number of
-                 *  libraries by quite a large number of compilers. We can fall back to DWARF unwind info
-                 *  in some cases, but in quite a number of cases (especially libraries not compiled in debug
-                 *  mode, only the compact unwind info may be available). Even more unfortunately, there is no
-                 *  way to detect such bogus compact unwind info (other than noticing the resulting segfault).
-                 *  What we do here is ugly, but necessary until the compact unwind info situation improves.
-                 *  We try to use the compact unwind info and if that results in a segfault, we retry with DWARF info.
-                 *  Note that in a small number of cases this may result in bogus stack traces, but at least the topmost
-                 *  entry will always be correct, and the number of cases in which this is an issue is rather small.
-                 *  Other than that, this implementation is not incorrect as the other thread is paused while we are profiling
-                 *  and during stack unwinding we only ever read memory, but never write it.
-                 */
-
-                forceDwarf = 0;
-                unw_getcontext(&profiler_uc); // will resume from this point if the next lines segfault at any point
-
-                if (forceDwarf == 0) {
-                    // Save the backtrace
-                    bt_size_cur += rec_backtrace_ctx((jl_bt_element_t*)bt_data_prof + bt_size_cur, bt_size_max - bt_size_cur - 1, uc, NULL);
-                }
-                else if (forceDwarf == 1) {
-                    bt_size_cur += rec_backtrace_ctx_dwarf((jl_bt_element_t*)bt_data_prof + bt_size_cur, bt_size_max - bt_size_cur - 1, uc, NULL);
-                }
-                else if (forceDwarf == -1) {
-                    jl_safe_printf("WARNING: profiler attempt to access an invalid memory location\n");
-                }
-
-                forceDwarf = -2;
-#else
-                bt_size_cur += rec_backtrace_ctx((jl_bt_element_t*)bt_data_prof + bt_size_cur, bt_size_max - bt_size_cur - 1, uc, NULL);
-#endif
-                jl_ptls_t ptls = jl_atomic_load_relaxed(&jl_all_tls_states)[i];
-
-                // store threadid but add 1 as 0 is preserved to indicate end of block
-                bt_data_prof[bt_size_cur++].uintptr = ptls->tid + 1;
-
-                // store task id (never null)
-                bt_data_prof[bt_size_cur++].jlvalue = (jl_value_t*)jl_atomic_load_relaxed(&ptls->current_task);
-
-                // store cpu cycle clock
-                bt_data_prof[bt_size_cur++].uintptr = cycleclock();
-
-                // store whether thread is sleeping but add 1 as 0 is preserved to indicate end of block
-                bt_data_prof[bt_size_cur++].uintptr = jl_atomic_load_relaxed(&ptls->sleep_check_state) + 1;
-
-                // Mark the end of this block with two 0's
-                bt_data_prof[bt_size_cur++].uintptr = 0;
-                bt_data_prof[bt_size_cur++].uintptr = 0;
-            }
-            // We're done! Resume the thread.
-            jl_thread_resume(i);
         }
         jl_unlock_profile_mach(0, keymgr_locked);
         if (running) {
@@ -709,6 +643,84 @@ void *mach_profile_listener(void *arg)
         }
     }
 }
+
+// assumes holding `jl_lock_profile_mach`
+void jl_profile_thread(int tid)
+{
+    // if there is no space left, return early
+    if (jl_profile_is_buffer_full()) {
+        jl_profile_stop_timer();
+        return;
+    }
+    if (_dyld_dlopen_atfork_prepare != NULL && _dyld_dlopen_atfork_parent != NULL)
+        _dyld_dlopen_atfork_prepare();
+    if (_dyld_atfork_prepare != NULL && _dyld_atfork_parent != NULL)
+        _dyld_atfork_prepare(); // briefly acquire the dlsym lock
+    host_thread_state_t state;
+    int valid_thread = jl_thread_suspend_and_get_state2(tid, &state);
+    unw_context_t *uc = (unw_context_t*)&state;
+    if (_dyld_atfork_prepare != NULL && _dyld_atfork_parent != NULL)
+        _dyld_atfork_parent(); // quickly release the dlsym lock
+    if (_dyld_dlopen_atfork_prepare != NULL && _dyld_dlopen_atfork_parent != NULL)
+        _dyld_dlopen_atfork_parent();
+    if (!valid_thread)
+        return;
+    if (running) {
+#ifdef LLVMLIBUNWIND
+        /*
+            *  Unfortunately compact unwind info is incorrectly generated for quite a number of
+            *  libraries by quite a large number of compilers. We can fall back to DWARF unwind info
+            *  in some cases, but in quite a number of cases (especially libraries not compiled in debug
+            *  mode, only the compact unwind info may be available). Even more unfortunately, there is no
+            *  way to detect such bogus compact unwind info (other than noticing the resulting segfault).
+            *  What we do here is ugly, but necessary until the compact unwind info situation improves.
+            *  We try to use the compact unwind info and if that results in a segfault, we retry with DWARF info.
+            *  Note that in a small number of cases this may result in bogus stack traces, but at least the topmost
+            *  entry will always be correct, and the number of cases in which this is an issue is rather small.
+            *  Other than that, this implementation is not incorrect as the other thread is paused while we are profiling
+            *  and during stack unwinding we only ever read memory, but never write it.
+            */
+
+        forceDwarf = 0;
+        unw_getcontext(&profiler_uc); // will resume from this point if the next lines segfault at any point
+
+        if (forceDwarf == 0) {
+            // Save the backtrace
+            bt_size_cur += rec_backtrace_ctx((jl_bt_element_t*)bt_data_prof + bt_size_cur, bt_size_max - bt_size_cur - 1, uc, NULL);
+        }
+        else if (forceDwarf == 1) {
+            bt_size_cur += rec_backtrace_ctx_dwarf((jl_bt_element_t*)bt_data_prof + bt_size_cur, bt_size_max - bt_size_cur - 1, uc, NULL);
+        }
+        else if (forceDwarf == -1) {
+            jl_safe_printf("WARNING: profiler attempt to access an invalid memory location\n");
+        }
+
+        forceDwarf = -2;
+#else
+        bt_size_cur += rec_backtrace_ctx((jl_bt_element_t*)bt_data_prof + bt_size_cur, bt_size_max - bt_size_cur - 1, uc, NULL);
+#endif
+        jl_ptls_t ptls = jl_atomic_load_relaxed(&jl_all_tls_states)[tid];
+
+        // store threadid but add 1 as 0 is preserved to indicate end of block
+        bt_data_prof[bt_size_cur++].uintptr = ptls->tid + 1;
+
+        // store task id (never null)
+        bt_data_prof[bt_size_cur++].jlvalue = (jl_value_t*)jl_atomic_load_relaxed(&ptls->current_task);
+
+        // store cpu cycle clock
+        bt_data_prof[bt_size_cur++].uintptr = cycleclock();
+
+        // store whether thread is sleeping but add 1 as 0 is preserved to indicate end of block
+        bt_data_prof[bt_size_cur++].uintptr = jl_atomic_load_relaxed(&ptls->sleep_check_state) + 1;
+
+        // Mark the end of this block with two 0's
+        bt_data_prof[bt_size_cur++].uintptr = 0;
+        bt_data_prof[bt_size_cur++].uintptr = 0;
+    }
+    // We're done! Resume the thread.
+    jl_thread_resume(tid);
+}
+
 
 JL_DLLEXPORT int jl_profile_start_timer(uint8_t all_tasks)
 {

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -718,7 +718,7 @@ void jl_profile_thread_unix(int tid, bt_context_t *signal_context)
         return;
     }
     // notify thread to stop
-    if (!jl_thread_suspend_and_get_state(tid, 1, &signal_context))
+    if (!jl_thread_suspend_and_get_state(tid, 1, signal_context))
         return;
     // unwinding can fail, so keep track of the current state
     // and restore from the SEGV handler if anything happens.
@@ -731,7 +731,7 @@ void jl_profile_thread_unix(int tid, bt_context_t *signal_context)
     } else {
         // Get backtrace data
         bt_size_cur += rec_backtrace_ctx((jl_bt_element_t*)bt_data_prof + bt_size_cur,
-                bt_size_max - bt_size_cur - 1, &signal_context, NULL);
+                bt_size_max - bt_size_cur - 1, signal_context, NULL);
     }
     jl_set_safe_restore(old_buf);
 
@@ -922,7 +922,7 @@ static void *signal_listener(void *arg)
             else {
                 int *randperm = profile_get_randperm(nthreads);
                 for (int idx = nthreads; idx-- > 0; ) {
-                    // Stop the threads in the random or reverse round-robin order.
+                    // Stop the threads in the random order.
                     int i = randperm[idx];
                     // do backtrace for profiler
                     if (profile && running) {

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -753,6 +753,22 @@ JL_DLLEXPORT void jl_profile_task_unix(size_t nthreads, bt_context_t *signal_con
     jl_safe_printf("Profiling task %p\n", t);
 
     jl_rec_backtrace(t);
+
+    // store threadid but add 1 as 0 is preserved to indicate end of block
+    bt_data_prof[bt_size_cur++].uintptr = UINTPTR_MAX; // dummy value for now... Is this ever used when outputting the profile?
+
+    // store task id (never null)
+    bt_data_prof[bt_size_cur++].jlvalue = (jl_value_t*)t;
+
+    // store cpu cycle clock. XXX(Diogo, Nick): why are we recording the cycleclock here?
+    bt_data_prof[bt_size_cur++].uintptr = cycleclock();
+
+    // store whether thread is sleeping but add 1 as 0 is preserved to indicate end of block
+    bt_data_prof[bt_size_cur++].uintptr = UINTPTR_MAX; // dummy value for now... Is this ever used when outputting the profile?
+
+    // Mark the end of this block with two 0's
+    bt_data_prof[bt_size_cur++].uintptr = 0;
+    bt_data_prof[bt_size_cur++].uintptr = 0;
 }
 
 void jl_profile_thread_unix(int tid, bt_context_t *signal_context)

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -709,7 +709,51 @@ void trigger_profile_peek(void)
         profile_autostop_time = jl_hrtime() + (profile_peek_duration * 1e9);
 }
 
+// Return a task to profile (for all_task profiler)
+// We need to select a task uniformly at random from the set of all tasks.
+// TODO(PR) Optimize this!
+// TODO(PR) don't export this
+JL_DLLEXPORT jl_task_t *jl_profile_select_task(size_t nthreads)
+{
+    jl_ptls_t *allstates = jl_atomic_load_relaxed(&jl_all_tls_states);
+    // Racy selection of a task; `live_tasks` can change at any time.
+    // TODO: skip GC threads?
+    size_t total_tasks = 0;
+    for (int i = nthreads; i-- > 0; ) {
+        jl_ptls_t ptls = allstates[i];
+        small_arraylist_t *live_tasks = &ptls->gc_tls.heap.live_tasks;
+        total_tasks += mtarraylist_length(live_tasks);
+    }
+    size_t rn = jl_rand() % total_tasks;
+    for (int i = nthreads; i-- > 0; ) {
+        jl_ptls_t ptls = allstates[i];
+        small_arraylist_t *live_tasks = &ptls->gc_tls.heap.live_tasks;
+        size_t ntasks = mtarraylist_length(live_tasks);
+        if (rn <= ntasks) {
+            // NULL if rn is out of bounds
+            return (jl_task_t*)mtarraylist_get(live_tasks, rn);
+        }
+        rn -= ntasks;
+    }
+}
+
 // assumes holding `jl_lock_stackwalk`
+void jl_profile_task_unix(jl_task_t *t, bt_context_t *signal_context)
+{
+    if (jl_profile_is_buffer_full()) {
+        // Buffer full: Delete the timer
+        jl_profile_stop_timer();
+        return;
+    }
+    if (t == NULL)
+        return;
+    int t_state = jl_atomic_load_relaxed(&t->_state);
+    if (t_state == JL_TASK_STATE_DONE)
+        return;
+    // jl_rec_backtrace(t);
+    // TODO write the recorded backtrace to the profile buffer
+}
+
 void jl_profile_thread_unix(int tid, bt_context_t *signal_context)
 {
     if (jl_profile_is_buffer_full()) {
@@ -916,8 +960,10 @@ static void *signal_listener(void *arg)
         }
         else if (profile) {
             if (profile_all_tasks) {
-                // t = select_task()
-                // jl_profile_task()
+                jl_task_t *t = jl_profile_select_task(nthreads);
+                jl_safe_printf("Profiling task %p\n", (void*)t);
+                // if t is NULL, skip
+                // jl_profile_task_unix(t, &signal_context);
             }
             else {
                 int *randperm = profile_get_randperm(nthreads);

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -562,7 +562,7 @@ int timer_graceperiod_elapsed(void)
 static timer_t timerprof;
 static struct itimerspec itsprof;
 
-JL_DLLEXPORT int jl_profile_start_timer(void)
+JL_DLLEXPORT int jl_profile_start_timer(uint8_t all_tasks)
 {
     struct sigevent sigprof;
 
@@ -573,8 +573,10 @@ JL_DLLEXPORT int jl_profile_start_timer(void)
     sigprof.sigev_value.sival_ptr = &timerprof;
     // Because SIGUSR1 is multipurpose, set `running` before so that we know that the first SIGUSR1 came from the timer
     running = 1;
+    profile_all_tasks = all_tasks;
     if (timer_create(CLOCK_REALTIME, &sigprof, &timerprof) == -1) {
         running = 0;
+        profile_all_tasks = 0;
         return -2;
     }
 
@@ -585,6 +587,7 @@ JL_DLLEXPORT int jl_profile_start_timer(void)
     itsprof.it_value.tv_nsec = nsecprof % GIGA;
     if (timer_settime(timerprof, 0, &itsprof, NULL) == -1) {
         running = 0;
+        profile_all_tasks = 0;
         return -3;
     }
     return 0;

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -449,7 +449,7 @@ static DWORD WINAPI profile_bt( LPVOID lparam )
 
 static volatile TIMECAPS timecaps;
 
-JL_DLLEXPORT int jl_profile_start_timer(void)
+JL_DLLEXPORT int jl_profile_start_timer(uint8_t all_tasks)
 {
     if (hBtThread == NULL) {
 
@@ -483,6 +483,7 @@ JL_DLLEXPORT int jl_profile_start_timer(void)
         if (TIMERR_NOERROR != timeBeginPeriod(timecaps.wPeriodMin))
             timecaps.wPeriodMin = 0;
     }
+    profile_all_tasks = all_tasks;
     running = 1; // set `running` finally
     return 0;
 }
@@ -491,6 +492,7 @@ JL_DLLEXPORT void jl_profile_stop_timer(void)
     if (running && timecaps.wPeriodMin)
         timeEndPeriod(timecaps.wPeriodMin);
     running = 0;
+    profile_all_tasks = 0;
 }
 
 void jl_install_default_signal_handlers(void)

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -876,8 +876,18 @@ void jl_rec_backtrace(jl_task_t *t) JL_NOTSAFEPOINT
     jl_ptls_t ptls = ct->ptls;
     ptls->bt_size = 0;
     if (t == ct) {
-        ptls->bt_size = rec_backtrace(ptls->bt_data, JL_MAX_BT_SIZE, 0);
-        return;
+        // Record into the profile buffer
+        if (running && profile_all_tasks) {
+            bt_size_cur += rec_backtrace(
+                (jl_bt_element_t*)bt_data_prof + bt_size_cur,
+                bt_size_max - bt_size_cur - 1,
+                0);
+            return;
+        }
+        else {
+            ptls->bt_size = rec_backtrace(ptls->bt_data, JL_MAX_BT_SIZE, 0);
+            return;
+        }
     }
     bt_context_t *context = NULL;
     bt_context_t c;

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -13,7 +13,7 @@
 extern volatile jl_bt_element_t *bt_data_prof;
 extern volatile size_t bt_size_max;
 extern volatile size_t bt_size_cur;
-extern volatile int profile_running;
+extern volatile int running;
 extern volatile int profile_all_tasks;
 
 // define `jl_unw_get` as a macro, since (like setjmp)
@@ -1115,19 +1115,24 @@ static void jl_rec_backtrace(jl_task_t *t) JL_NOTSAFEPOINT
      #pragma message("jl_rec_backtrace not defined for unknown task system")
 #endif
     }
-    if (profile_running && profile_all_tasks)
-        bt_size_cur += rec_backtrace_ctx(
-          (jl_bt_element_t*)bt_data_prof + bt_size_cur,
-          bt_size_max - bt_size_cur - 1,
-          signal_context,
-          NULL);
-
-    else if (context)
-        ptls->bt_size = rec_backtrace_ctx(
-            ptls->bt_data,
-            JL_MAX_BT_SIZE,
-            context,
-            t->gcstack);
+    if (context) {
+        // Record into the profile buffer
+        if (running && profile_all_tasks) {
+            bt_size_cur += rec_backtrace_ctx(
+                (jl_bt_element_t*)bt_data_prof + bt_size_cur,
+                bt_size_max - bt_size_cur - 1,
+                context,
+                NULL);
+        }
+        // Record into the buffer owned by the threads's TLS
+        else {
+            ptls->bt_size = rec_backtrace_ctx(
+                ptls->bt_data,
+                JL_MAX_BT_SIZE,
+                context,
+                t->gcstack);
+        }
+    }
     if (old == -1)
         jl_atomic_store_relaxed(&t->tid, old);
     else if (old != ptls->tid)

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -10,12 +10,6 @@
 #include "threading.h"
 #include "julia_assert.h"
 
-extern volatile jl_bt_element_t *bt_data_prof;
-extern volatile size_t bt_size_max;
-extern volatile size_t bt_size_cur;
-extern volatile int running;
-extern volatile int profile_all_tasks;
-
 // define `jl_unw_get` as a macro, since (like setjmp)
 // returning from the callee function will invalidate the context
 #ifdef _OS_WINDOWS_
@@ -876,7 +870,7 @@ _os_ptr_munge(uintptr_t ptr)
 
 extern bt_context_t *jl_to_bt_context(void *sigctx);
 
-static void jl_rec_backtrace(jl_task_t *t) JL_NOTSAFEPOINT
+void jl_rec_backtrace(jl_task_t *t) JL_NOTSAFEPOINT
 {
     jl_task_t *ct = jl_current_task;
     jl_ptls_t ptls = ct->ptls;


### PR DESCRIPTION
## PR Description

_What does this PR do?_
WIP on [RAI-14413](https://relationalai.atlassian.net/browse/RAI-14413)

Misc todos:
- rename globals to make "profiling" clear (e.g. `running` -> `profile_running`, `bt_size_max` -> `prof_bt_size_max`)
- what to do about dropped samples?
  - put placeholder / dud value (rather than dropping samples)?
  - return true sample rate (given we dropped samples)?
  - resample? No, probably too slow or risks biasing the sample
- what's up with sticky tasks? these tasks always have a thread id set, so we're going to stop the thread it's "stuck" to... but we still need to now whether the thread was actually running the sticky task or not, to know what "context" to pass in 
  - check if the `ptls->current_task` is the sticky task we're trying to profile? if is is, fine. If not, what? How do we collect the backtrace?
  

## Checklist

Requirements for merging:
- [ ] I have opened an issue or PR upstream on JuliaLang/julia: <link to JuliaLang/julia>
- [ ] I have removed the `port-to-*` labels that don't apply.
- [ ] I have opened a PR on raicode to test these changes: <link to raicode>


[RAI-14413]: https://relationalai.atlassian.net/browse/RAI-14413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ