### PR TITLE
fix cmdlineargs test in our fork

### DIFF
--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -363,7 +363,7 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
     # --gcthreads
     code = "print(Threads.ngcthreads())"
     cpu_threads = ccall(:jl_effective_threads, Int32, ())
-    @test (cpu_threads == 1 ? "1" : string(div(cpu_threads, 2))) ==
+    @test string(cpu_threads) ==
           read(`$exename --threads auto -e $code`, String) ==
           read(`$exename --threads=auto -e $code`, String) ==
           read(`$exename -tauto -e $code`, String) ==

--- a/test/gc.jl
+++ b/test/gc.jl
@@ -43,4 +43,3 @@ end
     run_nonzero_page_utilization_test()
     run_pg_size_test()
 end
-


### PR DESCRIPTION
## PR Description

We set the number of GC threads in our fork to the number of mutators (not half of it, as it's done upstream).

## Checklist

Requirements for merging:
- [x] I have opened an issue or PR upstream on JuliaLang/julia: N/A.
- [x] I have removed the `port-to-*` labels that don't apply.
- [x] I have opened a PR on raicode to test these changes: https://github.com/RelationalAI/raicode/pull/21094.
