### PR TITLE
all tasks profiler

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -206,6 +206,18 @@ JL_DLLEXPORT void jl_unlock_profile_wr(void) JL_NOTSAFEPOINT JL_NOTSAFEPOINT_LEA
 int jl_lock_stackwalk(void) JL_NOTSAFEPOINT JL_NOTSAFEPOINT_ENTER;
 void jl_unlock_stackwalk(int lockret) JL_NOTSAFEPOINT JL_NOTSAFEPOINT_LEAVE;
 
+arraylist_t *jl_get_all_tasks_arraylist(void) JL_NOTSAFEPOINT;
+int jl_rec_backtrace(jl_task_t *t) JL_NOTSAFEPOINT;
+extern volatile struct _jl_bt_element_t *profile_bt_data_prof;
+extern volatile size_t profile_bt_size_max;
+extern volatile size_t profile_bt_size_cur;
+extern volatile int profile_running;
+extern volatile int profile_all_tasks;
+STATIC_INLINE int all_tasks_profile_running(void) JL_NOTSAFEPOINT
+{
+    return profile_running && profile_all_tasks;
+}
+
 // number of cycles since power-on
 static inline uint64_t cycleclock(void) JL_NOTSAFEPOINT
 {

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -18,16 +18,16 @@ extern "C" {
 #include <threading.h>
 
 // Profiler control variables
-// Note: these "static" variables are also used in "signals-*.c"
-static volatile jl_bt_element_t *bt_data_prof = NULL;
-static volatile size_t bt_size_max = 0;
-static volatile size_t bt_size_cur = 0;
+volatile jl_bt_element_t *profile_bt_data_prof = NULL;
+volatile size_t profile_bt_size_max = 0;
+volatile size_t profile_bt_size_cur = 0;
 static volatile uint64_t nsecprof = 0;
-static volatile int running = 0;
-static const    uint64_t GIGA = 1000000000ULL;
+volatile int profile_running = 0;
+volatile int profile_all_tasks = 0;
+static const uint64_t GIGA = 1000000000ULL;
 // Timers to take samples at intervals
 JL_DLLEXPORT void jl_profile_stop_timer(void);
-JL_DLLEXPORT int jl_profile_start_timer(void);
+JL_DLLEXPORT int jl_profile_start_timer(uint8_t);
 // File-descriptor for safe logging on signal handling
 int jl_sig_fd;
 
@@ -36,30 +36,30 @@ int jl_sig_fd;
 ///////////////////////
 JL_DLLEXPORT int jl_profile_init(size_t maxsize, uint64_t delay_nsec)
 {
-    bt_size_max = maxsize;
+    profile_bt_size_max = maxsize;
     nsecprof = delay_nsec;
-    if (bt_data_prof != NULL)
-        free((void*)bt_data_prof);
-    bt_data_prof = (jl_bt_element_t*) calloc(maxsize, sizeof(jl_bt_element_t));
-    if (bt_data_prof == NULL && maxsize > 0)
+    if (profile_bt_data_prof != NULL)
+        free((void*)profile_bt_data_prof);
+    profile_bt_data_prof = (jl_bt_element_t*) calloc(maxsize, sizeof(jl_bt_element_t));
+    if (profile_bt_data_prof == NULL && maxsize > 0)
         return -1;
-    bt_size_cur = 0;
+    profile_bt_size_cur = 0;
     return 0;
 }
 
 JL_DLLEXPORT uint8_t *jl_profile_get_data(void)
 {
-    return (uint8_t*) bt_data_prof;
+    return (uint8_t*) profile_bt_data_prof;
 }
 
 JL_DLLEXPORT size_t jl_profile_len_data(void)
 {
-    return bt_size_cur;
+    return profile_bt_size_cur;
 }
 
 JL_DLLEXPORT size_t jl_profile_maxlen_data(void)
 {
-    return bt_size_max;
+    return profile_bt_size_max;
 }
 
 JL_DLLEXPORT uint64_t jl_profile_delay_nsec(void)
@@ -69,12 +69,12 @@ JL_DLLEXPORT uint64_t jl_profile_delay_nsec(void)
 
 JL_DLLEXPORT void jl_profile_clear_data(void)
 {
-    bt_size_cur = 0;
+    profile_bt_size_cur = 0;
 }
 
 JL_DLLEXPORT int jl_profile_is_running(void)
 {
-    return running;
+    return profile_running;
 }
 
 // Any function that acquires this lock must be either a unmanaged thread
@@ -187,7 +187,7 @@ JL_DLLEXPORT int jl_profile_is_buffer_full(void)
     // Declare buffer full if there isn't enough room to sample even just the
     // thread metadata and one max-sized frame. The `+ 6` is for the two block
     // terminator `0`'s plus the 4 metadata entries.
-    return bt_size_cur + ((JL_BT_MAX_ENTRY_SIZE + 1) + 6) > bt_size_max;
+    return profile_bt_size_cur + ((JL_BT_MAX_ENTRY_SIZE + 1) + 6) > profile_bt_size_max;
 }
 
 static uint64_t jl_last_sigint_trigger = 0;

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -603,6 +603,85 @@ void jl_unlock_stackwalk(int lockret)
     jl_unlock_profile_mach(1, lockret);
 }
 
+// assumes holding `jl_lock_profile_mach`
+void jl_profile_thread_mach(int tid)
+{
+    // if there is no space left, return early
+    if (jl_profile_is_buffer_full()) {
+        jl_profile_stop_timer();
+        return;
+    }
+    if (_dyld_dlopen_atfork_prepare != NULL && _dyld_dlopen_atfork_parent != NULL)
+        _dyld_dlopen_atfork_prepare();
+    if (_dyld_atfork_prepare != NULL && _dyld_atfork_parent != NULL)
+        _dyld_atfork_prepare(); // briefly acquire the dlsym lock
+    host_thread_state_t state;
+    int valid_thread = jl_thread_suspend_and_get_state2(tid, &state);
+    unw_context_t *uc = (unw_context_t*)&state;
+    if (_dyld_atfork_prepare != NULL && _dyld_atfork_parent != NULL)
+        _dyld_atfork_parent(); // quickly release the dlsym lock
+    if (_dyld_dlopen_atfork_prepare != NULL && _dyld_dlopen_atfork_parent != NULL)
+        _dyld_dlopen_atfork_parent();
+    if (!valid_thread)
+        return;
+    if (profile_running) {
+#ifdef LLVMLIBUNWIND
+        /*
+            *  Unfortunately compact unwind info is incorrectly generated for quite a number of
+            *  libraries by quite a large number of compilers. We can fall back to DWARF unwind info
+            *  in some cases, but in quite a number of cases (especially libraries not compiled in debug
+            *  mode, only the compact unwind info may be available). Even more unfortunately, there is no
+            *  way to detect such bogus compact unwind info (other than noticing the resulting segfault).
+            *  What we do here is ugly, but necessary until the compact unwind info situation improves.
+            *  We try to use the compact unwind info and if that results in a segfault, we retry with DWARF info.
+            *  Note that in a small number of cases this may result in bogus stack traces, but at least the topmost
+            *  entry will always be correct, and the number of cases in which this is an issue is rather small.
+            *  Other than that, this implementation is not incorrect as the other thread is paused while we are profiling
+            *  and during stack unwinding we only ever read memory, but never write it.
+            */
+
+        forceDwarf = 0;
+        unw_getcontext(&profiler_uc); // will resume from this point if the next lines segfault at any point
+
+        if (forceDwarf == 0) {
+            // Save the backtrace
+            profile_bt_size_cur += rec_backtrace_ctx((jl_bt_element_t*)profile_bt_data_prof + profile_bt_size_cur, profile_bt_size_max - profile_bt_size_cur - 1, uc, NULL);
+        }
+        else if (forceDwarf == 1) {
+            profile_bt_size_cur += rec_backtrace_ctx_dwarf((jl_bt_element_t*)profile_bt_data_prof + profile_bt_size_cur, profile_bt_size_max - profile_bt_size_cur - 1, uc, NULL);
+        }
+        else if (forceDwarf == -1) {
+            jl_safe_printf("WARNING: profiler attempt to access an invalid memory location\n");
+        }
+
+        forceDwarf = -2;
+#else
+        profile_bt_size_cur += rec_backtrace_ctx((jl_bt_element_t*)profile_bt_data_prof + profile_bt_size_cur, profile_bt_size_max - profile_bt_size_cur - 1, uc, NULL);
+#endif
+        jl_ptls_t ptls = jl_atomic_load_relaxed(&jl_all_tls_states)[tid];
+
+        // store threadid but add 1 as 0 is preserved to indicate end of block
+        profile_bt_data_prof[profile_bt_size_cur++].uintptr = ptls->tid + 1;
+
+        // store task id (never null)
+        profile_bt_data_prof[profile_bt_size_cur++].jlvalue = (jl_value_t*)jl_atomic_load_relaxed(&ptls->current_task);
+
+        // store cpu cycle clock
+        profile_bt_data_prof[profile_bt_size_cur++].uintptr = cycleclock();
+
+        // store whether thread is sleeping but add 1 as 0 is preserved to indicate end of block
+        profile_bt_data_prof[profile_bt_size_cur++].uintptr = jl_atomic_load_relaxed(&ptls->sleep_check_state) + 1;
+
+        // Mark the end of this block with two 0's
+        profile_bt_data_prof[profile_bt_size_cur++].uintptr = 0;
+        profile_bt_data_prof[profile_bt_size_cur++].uintptr = 0;
+    }
+    // We're done! Resume the thread.
+    jl_thread_resume(tid);
+}
+
+void jl_profile_task_unix(void);
+
 void *mach_profile_listener(void *arg)
 {
     (void)arg;
@@ -620,88 +699,21 @@ void *mach_profile_listener(void *arg)
         // sample each thread, round-robin style in reverse order
         // (so that thread zero gets notified last)
         int keymgr_locked = jl_lock_profile_mach(0);
-
         int nthreads = jl_atomic_load_acquire(&jl_n_threads);
-        int *randperm = profile_get_randperm(nthreads);
-        for (int idx = nthreads; idx-- > 0; ) {
-            // Stop the threads in the random or reverse round-robin order.
-            int i = randperm[idx];
-            // if there is no space left, break early
-            if (jl_profile_is_buffer_full()) {
-                jl_profile_stop_timer();
-                break;
+        if (profile_all_tasks) {
+            // Don't take the stackwalk lock here since it's already taken in `jl_rec_backtrace`
+            jl_profile_task_unix();
+        }
+        else {
+            int *randperm = profile_get_randperm(nthreads);
+            for (int idx = nthreads; idx-- > 0; ) {
+                // Stop the threads in random order.
+                int i = randperm[idx];
+                jl_profile_thread_mach(i);
             }
-
-            if (_dyld_dlopen_atfork_prepare != NULL && _dyld_dlopen_atfork_parent != NULL)
-                _dyld_dlopen_atfork_prepare();
-            if (_dyld_atfork_prepare != NULL && _dyld_atfork_parent != NULL)
-                _dyld_atfork_prepare(); // briefly acquire the dlsym lock
-            host_thread_state_t state;
-            int valid_thread = jl_thread_suspend_and_get_state2(i, &state);
-            unw_context_t *uc = (unw_context_t*)&state;
-            if (_dyld_atfork_prepare != NULL && _dyld_atfork_parent != NULL)
-                _dyld_atfork_parent(); // quickly release the dlsym lock
-            if (_dyld_dlopen_atfork_prepare != NULL && _dyld_dlopen_atfork_parent != NULL)
-                _dyld_dlopen_atfork_parent();
-            if (!valid_thread)
-                continue;
-            if (running) {
-#ifdef LLVMLIBUNWIND
-                /*
-                 *  Unfortunately compact unwind info is incorrectly generated for quite a number of
-                 *  libraries by quite a large number of compilers. We can fall back to DWARF unwind info
-                 *  in some cases, but in quite a number of cases (especially libraries not compiled in debug
-                 *  mode, only the compact unwind info may be available). Even more unfortunately, there is no
-                 *  way to detect such bogus compact unwind info (other than noticing the resulting segfault).
-                 *  What we do here is ugly, but necessary until the compact unwind info situation improves.
-                 *  We try to use the compact unwind info and if that results in a segfault, we retry with DWARF info.
-                 *  Note that in a small number of cases this may result in bogus stack traces, but at least the topmost
-                 *  entry will always be correct, and the number of cases in which this is an issue is rather small.
-                 *  Other than that, this implementation is not incorrect as the other thread is paused while we are profiling
-                 *  and during stack unwinding we only ever read memory, but never write it.
-                 */
-
-                forceDwarf = 0;
-                unw_getcontext(&profiler_uc); // will resume from this point if the next lines segfault at any point
-
-                if (forceDwarf == 0) {
-                    // Save the backtrace
-                    bt_size_cur += rec_backtrace_ctx((jl_bt_element_t*)bt_data_prof + bt_size_cur, bt_size_max - bt_size_cur - 1, uc, NULL);
-                }
-                else if (forceDwarf == 1) {
-                    bt_size_cur += rec_backtrace_ctx_dwarf((jl_bt_element_t*)bt_data_prof + bt_size_cur, bt_size_max - bt_size_cur - 1, uc, NULL);
-                }
-                else if (forceDwarf == -1) {
-                    jl_safe_printf("WARNING: profiler attempt to access an invalid memory location\n");
-                }
-
-                forceDwarf = -2;
-#else
-                bt_size_cur += rec_backtrace_ctx((jl_bt_element_t*)bt_data_prof + bt_size_cur, bt_size_max - bt_size_cur - 1, uc, NULL);
-#endif
-                jl_ptls_t ptls = jl_atomic_load_relaxed(&jl_all_tls_states)[i];
-
-                // store threadid but add 1 as 0 is preserved to indicate end of block
-                bt_data_prof[bt_size_cur++].uintptr = ptls->tid + 1;
-
-                // store task id (never null)
-                bt_data_prof[bt_size_cur++].jlvalue = (jl_value_t*)jl_atomic_load_relaxed(&ptls->current_task);
-
-                // store cpu cycle clock
-                bt_data_prof[bt_size_cur++].uintptr = cycleclock();
-
-                // store whether thread is sleeping but add 1 as 0 is preserved to indicate end of block
-                bt_data_prof[bt_size_cur++].uintptr = jl_atomic_load_relaxed(&ptls->sleep_check_state) + 1;
-
-                // Mark the end of this block with two 0's
-                bt_data_prof[bt_size_cur++].uintptr = 0;
-                bt_data_prof[bt_size_cur++].uintptr = 0;
-            }
-            // We're done! Resume the thread.
-            jl_thread_resume(i);
         }
         jl_unlock_profile_mach(0, keymgr_locked);
-        if (running) {
+        if (profile_running) {
             jl_check_profile_autostop();
             // Reset the alarm
             kern_return_t ret = clock_alarm(clk, TIME_RELATIVE, timerprof, profile_port);
@@ -710,7 +722,8 @@ void *mach_profile_listener(void *arg)
     }
 }
 
-JL_DLLEXPORT int jl_profile_start_timer(void)
+
+JL_DLLEXPORT int jl_profile_start_timer(uint8_t all_tasks)
 {
     kern_return_t ret;
     if (!profile_started) {
@@ -739,7 +752,8 @@ JL_DLLEXPORT int jl_profile_start_timer(void)
     timerprof.tv_sec = nsecprof/GIGA;
     timerprof.tv_nsec = nsecprof%GIGA;
 
-    running = 1;
+    profile_running = 1;
+    profile_all_tasks = all_tasks;
     // ensure the alarm is running
     ret = clock_alarm(clk, TIME_RELATIVE, timerprof, profile_port);
     HANDLE_MACH_ERROR("clock_alarm", ret);
@@ -749,5 +763,6 @@ JL_DLLEXPORT int jl_profile_start_timer(void)
 
 JL_DLLEXPORT void jl_profile_stop_timer(void)
 {
-    running = 0;
+    profile_running = 0;
+    profile_all_tasks = 0;
 }

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -9,6 +9,10 @@
 #include <pthread.h>
 #include <time.h>
 #include <errno.h>
+
+#include "julia.h"
+#include "julia_internal.h"
+
 #if defined(_OS_DARWIN_) && !defined(MAP_ANONYMOUS)
 #define MAP_ANONYMOUS MAP_ANON
 #endif
@@ -562,7 +566,7 @@ int timer_graceperiod_elapsed(void)
 static timer_t timerprof;
 static struct itimerspec itsprof;
 
-JL_DLLEXPORT int jl_profile_start_timer(void)
+JL_DLLEXPORT int jl_profile_start_timer(uint8_t all_tasks)
 {
     struct sigevent sigprof;
 
@@ -571,10 +575,12 @@ JL_DLLEXPORT int jl_profile_start_timer(void)
     sigprof.sigev_notify = SIGEV_SIGNAL;
     sigprof.sigev_signo = SIGUSR1;
     sigprof.sigev_value.sival_ptr = &timerprof;
-    // Because SIGUSR1 is multipurpose, set `running` before so that we know that the first SIGUSR1 came from the timer
-    running = 1;
+    // Because SIGUSR1 is multipurpose, set `profile_running` before so that we know that the first SIGUSR1 came from the timer
+    profile_running = 1;
+    profile_all_tasks = all_tasks;
     if (timer_create(CLOCK_REALTIME, &sigprof, &timerprof) == -1) {
-        running = 0;
+        profile_running = 0;
+        profile_all_tasks = 0;
         return -2;
     }
 
@@ -584,7 +590,8 @@ JL_DLLEXPORT int jl_profile_start_timer(void)
     itsprof.it_value.tv_sec = nsecprof / GIGA;
     itsprof.it_value.tv_nsec = nsecprof % GIGA;
     if (timer_settime(timerprof, 0, &itsprof, NULL) == -1) {
-        running = 0;
+        profile_running = 0;
+        profile_all_tasks = 0;
         return -3;
     }
     return 0;
@@ -592,10 +599,10 @@ JL_DLLEXPORT int jl_profile_start_timer(void)
 
 JL_DLLEXPORT void jl_profile_stop_timer(void)
 {
-    if (running) {
+    if (profile_running) {
         timer_delete(timerprof);
         last_timer_delete_time = jl_hrtime();
-        running = 0;
+        profile_running = 0;
     }
 }
 
@@ -691,7 +698,7 @@ void trigger_profile_peek(void)
     jl_safe_printf("\n======================================================================================\n");
     jl_safe_printf("Information request received. A stacktrace will print followed by a %.1f second profile\n", profile_peek_duration);
     jl_safe_printf("======================================================================================\n");
-    if (bt_size_max == 0){
+    if (profile_bt_size_max == 0){
         // If the buffer hasn't been initialized, initialize with default size
         // Keep these values synchronized with Profile.default_init()
         if (jl_profile_init(10000000, 1000000) == -1) {
@@ -699,11 +706,119 @@ void trigger_profile_peek(void)
             return;
         }
     }
-    bt_size_cur = 0; // clear profile buffer
-    if (jl_profile_start_timer() < 0)
+    profile_bt_size_cur = 0; // clear profile buffer
+    if (jl_profile_start_timer(0) < 0)
         jl_safe_printf("ERROR: Could not start profile timer\n");
     else
         profile_autostop_time = jl_hrtime() + (profile_peek_duration * 1e9);
+}
+
+void jl_profile_task_unix(void)
+{
+    if (jl_profile_is_buffer_full()) {
+        // Buffer full: Delete the timer
+        jl_profile_stop_timer();
+        return;
+    }
+
+    // Get a random task for which we know that we won't
+    // drop a sample in the profiler
+    // TODO(Diogo, Nick): should we put an upper bound on the number of iterations?
+    arraylist_t *tasks = jl_get_all_tasks_arraylist();
+    jl_task_t *t = NULL;
+    uint64_t seed = jl_rand();
+    while (1) {
+        t = tasks->items[cong(tasks->len, UINT64_MAX, &seed)];
+        assert(t == NULL || jl_is_task(t));
+        if (t == NULL) {
+            continue;
+        }
+        int t_state = jl_atomic_load_relaxed(&t->_state);
+        if (t_state == JL_TASK_STATE_DONE) {
+            continue;
+        }
+        break;
+    }
+    arraylist_free(tasks);
+    free(tasks);
+    assert(t != NULL);
+
+    int tid = jl_rec_backtrace(t);
+    // we failed to get a backtrace
+    // TODO(Diogo, Nick): should we add a special value to the buffer to indicate this?
+    // Should we retry? Note that dropping a backtraces affects the effective sample rate...
+    if (tid == INT16_MAX) {
+        return;
+    }
+    // TODO(Diogo, Nick): we were running the profiler on a Julia session with --threads=8 ans saw same samples
+    // from thread 16. Investigate whether this makes sense...
+
+    // store threadid but add 1 as 0 is preserved to indicate end of block
+    profile_bt_data_prof[profile_bt_size_cur++].uintptr = tid + 1;
+
+    // store task id (never null)
+    profile_bt_data_prof[profile_bt_size_cur++].jlvalue = (jl_value_t*)t;
+
+    // store cpu cycle clock
+    // TODO(Diogo, Nick): why are we storing the cycle clock here?
+    profile_bt_data_prof[profile_bt_size_cur++].uintptr = cycleclock();
+
+    // the thread profiler uses this block to record whether the thread is not sleeping (1) or sleeping (2)
+    // let's use a dummy value which is not 1 or 2 to
+    // indicate that we are profiling a task, and therefore, this block is not about the thread state
+    profile_bt_data_prof[profile_bt_size_cur++].uintptr = 3;
+
+    // Mark the end of this block with two 0's
+    profile_bt_data_prof[profile_bt_size_cur++].uintptr = 0;
+    profile_bt_data_prof[profile_bt_size_cur++].uintptr = 0;
+}
+
+// assumes holding `jl_lock_stackwalk`
+void jl_profile_thread_unix(int tid, bt_context_t *signal_context)
+{
+    if (jl_profile_is_buffer_full()) {
+        // Buffer full: Delete the timer
+        jl_profile_stop_timer();
+        return;
+    }
+    // notify thread to stop
+    if (!jl_thread_suspend_and_get_state(tid, 1, signal_context))
+        return;
+    // unwinding can fail, so keep track of the current state
+    // and restore from the SEGV handler if anything happens.
+    jl_jmp_buf *old_buf = jl_get_safe_restore();
+    jl_jmp_buf buf;
+
+    jl_set_safe_restore(&buf);
+    if (jl_setjmp(buf, 0)) {
+        jl_safe_printf("WARNING: profiler attempt to access an invalid memory location\n");
+    } else {
+        // Get backtrace data
+        profile_bt_size_cur += rec_backtrace_ctx((jl_bt_element_t*)profile_bt_data_prof + profile_bt_size_cur,
+                profile_bt_size_max - profile_bt_size_cur - 1, signal_context, NULL);
+    }
+    jl_set_safe_restore(old_buf);
+
+    jl_ptls_t ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[tid];
+
+    // store threadid but add 1 as 0 is preserved to indicate end of block
+    profile_bt_data_prof[profile_bt_size_cur++].uintptr = ptls2->tid + 1;
+
+    // store task id (never null)
+    profile_bt_data_prof[profile_bt_size_cur++].jlvalue = (jl_value_t*)jl_atomic_load_relaxed(&ptls2->current_task);
+
+    // store cpu cycle clock
+    profile_bt_data_prof[profile_bt_size_cur++].uintptr = cycleclock();
+
+    // store whether thread is sleeping but add 1 as 0 is preserved to indicate end of block
+    profile_bt_data_prof[profile_bt_size_cur++].uintptr = jl_atomic_load_relaxed(&ptls2->sleep_check_state) + 1;
+
+    // Mark the end of this block with two 0's
+    profile_bt_data_prof[profile_bt_size_cur++].uintptr = 0;
+    profile_bt_data_prof[profile_bt_size_cur++].uintptr = 0;
+
+    // notify thread to resume
+    jl_thread_resume(tid);
 }
 
 static void *signal_listener(void *arg)
@@ -805,13 +920,13 @@ static void *signal_listener(void *arg)
         int doexit = critical;
 #ifdef SIGINFO
         if (sig == SIGINFO) {
-            if (running != 1)
+            if (profile_running != 1)
                 trigger_profile_peek();
             doexit = 0;
         }
 #else
         if (sig == SIGUSR1) {
-            if (running != 1 && timer_graceperiod_elapsed())
+            if (profile_running != 1 && timer_graceperiod_elapsed())
                 trigger_profile_peek();
             doexit = 0;
         }
@@ -845,78 +960,46 @@ static void *signal_listener(void *arg)
         bt_size = 0;
 #if !defined(JL_DISABLE_LIBUNWIND)
         bt_context_t signal_context;
-        // sample each thread, round-robin style in reverse order
-        // (so that thread zero gets notified last)
-        if (critical || profile) {
+        if (critical) {
             int lockret = jl_lock_stackwalk();
-            int *randperm;
-            if (profile)
-                 randperm = profile_get_randperm(nthreads);
-            for (int idx = nthreads; idx-- > 0; ) {
-                // Stop the threads in the random or reverse round-robin order.
-                int i = profile ? randperm[idx] : idx;
+            // sample each thread, round-robin style in reverse order
+            // (so that thread zero gets notified last)
+            for (int i = nthreads; i-- > 0; ) {
                 // notify thread to stop
                 if (!jl_thread_suspend_and_get_state(i, 1, &signal_context))
                     continue;
 
                 // do backtrace on thread contexts for critical signals
                 // this part must be signal-handler safe
-                if (critical) {
-                    bt_size += rec_backtrace_ctx(bt_data + bt_size,
-                            JL_MAX_BT_SIZE / nthreads - 1,
-                            &signal_context, NULL);
-                    bt_data[bt_size++].uintptr = 0;
-                }
-
-                // do backtrace for profiler
-                if (profile && running) {
-                    if (jl_profile_is_buffer_full()) {
-                        // Buffer full: Delete the timer
-                        jl_profile_stop_timer();
-                    }
-                    else {
-                        // unwinding can fail, so keep track of the current state
-                        // and restore from the SEGV handler if anything happens.
-                        jl_jmp_buf *old_buf = jl_get_safe_restore();
-                        jl_jmp_buf buf;
-
-                        jl_set_safe_restore(&buf);
-                        if (jl_setjmp(buf, 0)) {
-                            jl_safe_printf("WARNING: profiler attempt to access an invalid memory location\n");
-                        } else {
-                            // Get backtrace data
-                            bt_size_cur += rec_backtrace_ctx((jl_bt_element_t*)bt_data_prof + bt_size_cur,
-                                    bt_size_max - bt_size_cur - 1, &signal_context, NULL);
-                        }
-                        jl_set_safe_restore(old_buf);
-
-                        jl_ptls_t ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[i];
-
-                        // store threadid but add 1 as 0 is preserved to indicate end of block
-                        bt_data_prof[bt_size_cur++].uintptr = ptls2->tid + 1;
-
-                        // store task id (never null)
-                        bt_data_prof[bt_size_cur++].jlvalue = (jl_value_t*)jl_atomic_load_relaxed(&ptls2->current_task);
-
-                        // store cpu cycle clock
-                        bt_data_prof[bt_size_cur++].uintptr = cycleclock();
-
-                        // store whether thread is sleeping but add 1 as 0 is preserved to indicate end of block
-                        bt_data_prof[bt_size_cur++].uintptr = jl_atomic_load_relaxed(&ptls2->sleep_check_state) + 1;
-
-                        // Mark the end of this block with two 0's
-                        bt_data_prof[bt_size_cur++].uintptr = 0;
-                        bt_data_prof[bt_size_cur++].uintptr = 0;
-                    }
-                }
-
-                // notify thread to resume
+                bt_size += rec_backtrace_ctx(bt_data + bt_size,
+                        JL_MAX_BT_SIZE / nthreads - 1,
+                        &signal_context, NULL);
+                bt_data[bt_size++].uintptr = 0;
                 jl_thread_resume(i);
             }
             jl_unlock_stackwalk(lockret);
         }
+        else if (profile) {
+            if (profile_all_tasks) {
+                // Don't take the stackwalk lock here since it's already taken in `jl_rec_backtrace`
+                jl_profile_task_unix();
+            }
+            else {
+                int lockret = jl_lock_stackwalk();
+                int *randperm = profile_get_randperm(nthreads);
+                for (int idx = nthreads; idx-- > 0; ) {
+                    // Stop the threads in the random order.
+                    int i = randperm[idx];
+                    // do backtrace for profiler
+                    if (profile && profile_running) {
+                        jl_profile_thread_unix(i, &signal_context);
+                    }
+                }
+                jl_unlock_stackwalk(lockret);
+            }
+        }
 #ifndef HAVE_MACH
-        if (profile && running) {
+        if (profile && profile_running) {
             jl_check_profile_autostop();
 #if defined(HAVE_TIMER)
             timer_settime(timerprof, 0, &itsprof, NULL);

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -398,7 +398,7 @@ static DWORD WINAPI profile_bt( LPVOID lparam )
     while (1) {
         DWORD timeout_ms = nsecprof / (GIGA / 1000);
         Sleep(timeout_ms > 0 ? timeout_ms : 1);
-        if (running) {
+        if (profile_running) {
             if (jl_profile_is_buffer_full()) {
                 jl_profile_stop_timer(); // does not change the thread state
                 SuspendThread(GetCurrentThread());
@@ -415,26 +415,26 @@ static DWORD WINAPI profile_bt( LPVOID lparam )
                     break;
                 }
                 // Get backtrace data
-                bt_size_cur += rec_backtrace_ctx((jl_bt_element_t*)bt_data_prof + bt_size_cur,
-                        bt_size_max - bt_size_cur - 1, &ctxThread, NULL);
+                profile_bt_size_cur += rec_backtrace_ctx((jl_bt_element_t*)profile_bt_data_prof + profile_bt_size_cur,
+                        profile_bt_size_max - profile_bt_size_cur - 1, &ctxThread, NULL);
 
                 jl_ptls_t ptls = jl_atomic_load_relaxed(&jl_all_tls_states)[0]; // given only profiling hMainThread
 
-                // store threadid but add 1 as 0 is preserved to indicate end of block
-                bt_data_prof[bt_size_cur++].uintptr = ptls->tid + 1;
+                // META_OFFSET_THREADID store threadid but add 1 as 0 is preserved to indicate end of block
+                profile_bt_data_prof[profile_bt_size_cur++].uintptr = ptls->tid + 1;
 
-                // store task id (never null)
-                bt_data_prof[bt_size_cur++].jlvalue = (jl_value_t*)jl_atomic_load_relaxed(&ptls->current_task);
+                // META_OFFSET_TASKID store task id (never null)
+                profile_bt_data_prof[profile_bt_size_cur++].jlvalue = (jl_value_t*)jl_atomic_load_relaxed(&ptls->current_task);
 
-                // store cpu cycle clock
-                bt_data_prof[bt_size_cur++].uintptr = cycleclock();
+                // META_OFFSET_CPUCYCLECLOCK store cpu cycle clock
+                profile_bt_data_prof[profile_bt_size_cur++].uintptr = cycleclock();
 
-                // store whether thread is sleeping but add 1 as 0 is preserved to indicate end of block
-                bt_data_prof[bt_size_cur++].uintptr = jl_atomic_load_relaxed(&ptls->sleep_check_state) + 1;
+                // META_OFFSET_SLEEPSTATE store whether thread is sleeping but add 1 as 0 is preserved to indicate end of block
+                profile_bt_data_prof[profile_bt_size_cur++].uintptr = jl_atomic_load_relaxed(&ptls->sleep_check_state) + 1;
 
                 // Mark the end of this block with two 0's
-                bt_data_prof[bt_size_cur++].uintptr = 0;
-                bt_data_prof[bt_size_cur++].uintptr = 0;
+                profile_bt_data_prof[profile_bt_size_cur++].uintptr = 0;
+                profile_bt_data_prof[profile_bt_size_cur++].uintptr = 0;
                 jl_unlock_stackwalk(lockret);
                 jl_thread_resume(0);
                 jl_check_profile_autostop();
@@ -449,7 +449,7 @@ static DWORD WINAPI profile_bt( LPVOID lparam )
 
 static volatile TIMECAPS timecaps;
 
-JL_DLLEXPORT int jl_profile_start_timer(void)
+JL_DLLEXPORT int jl_profile_start_timer(uint8_t all_tasks)
 {
     if (hBtThread == NULL) {
 
@@ -477,20 +477,22 @@ JL_DLLEXPORT int jl_profile_start_timer(void)
             return -2;
         }
     }
-    if (running == 0) {
+    if (profile_running == 0) {
         // Failure to change the timer resolution is not fatal. However, it is important to
         // ensure that the timeBeginPeriod/timeEndPeriod is paired.
         if (TIMERR_NOERROR != timeBeginPeriod(timecaps.wPeriodMin))
             timecaps.wPeriodMin = 0;
     }
-    running = 1; // set `running` finally
+    profile_all_tasks = all_tasks;
+    profile_running = 1; // set `profile_running` finally
     return 0;
 }
 JL_DLLEXPORT void jl_profile_stop_timer(void)
 {
-    if (running && timecaps.wPeriodMin)
+    if (profile_running && timecaps.wPeriodMin)
         timeEndPeriod(timecaps.wPeriodMin);
-    running = 0;
+    profile_running = 0;
+    profile_all_tasks = 0;
 }
 
 void jl_install_default_signal_handlers(void)

--- a/src/task.c
+++ b/src/task.c
@@ -1115,6 +1115,38 @@ JL_DLLEXPORT jl_task_t *jl_get_current_task(void)
     return pgcstack == NULL ? NULL : container_of(pgcstack, jl_task_t, gcstack);
 }
 
+extern int gc_first_tid;
+// Select a task at random to profile. Racy: `live_tasks` can change at any time.
+arraylist_t *jl_get_all_tasks_arraylist(void) JL_NOTSAFEPOINT
+{
+    arraylist_t *tasks = (arraylist_t*)malloc_s(sizeof(arraylist_t));
+    arraylist_new(tasks, 0);
+    size_t nthreads = jl_atomic_load_acquire(&jl_n_threads);
+    jl_ptls_t *allstates = jl_atomic_load_relaxed(&jl_all_tls_states);
+    for (size_t i = 0; i < nthreads; i++) {
+        // skip GC threads...
+        if (gc_first_tid <= i && i < gc_first_tid + jl_n_gcthreads) {
+            continue;
+        }
+        jl_ptls_t ptls2 = allstates[i];
+        if (ptls2 == NULL) {
+            continue;
+        }
+        jl_task_t *t = ptls2->root_task;
+        if (t->stkbuf != NULL) {
+            arraylist_push(tasks, t);
+        }
+        small_arraylist_t *live_tasks = &ptls2->gc_tls.heap.live_tasks;
+        size_t n = mtarraylist_length(live_tasks);
+        for (size_t i = 0; i < n; i++) {
+            jl_task_t *t = (jl_task_t*)mtarraylist_get(live_tasks, i);
+            if (t->stkbuf != NULL) {
+                arraylist_push(tasks, t);
+            }
+        }
+    }
+    return tasks;
+}
 
 #ifdef JL_HAVE_ASYNCIFY
 JL_DLLEXPORT jl_ucontext_t *task_ctx_ptr(jl_task_t *t)

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -31,6 +31,25 @@ macro profile(ex)
     end
 end
 
+export @profile_tasks
+
+"""
+    @profile_tasks
+
+`@profile_tasks <expression>` runs your expression while taking periodic backtraces of a sample of all live tasks (both running and not running).
+These are appended to an internal buffer of backtraces.
+"""
+macro profile_tasks(ex)
+    return quote
+        try
+            start_timer(true)
+            $(esc(ex))
+        finally
+            stop_timer()
+        end
+    end
+end
+
 # An internal function called to show the report after an information request (SIGINFO or SIGUSR1).
 function _peek_report()
     iob = IOBuffer()
@@ -369,9 +388,9 @@ end
 
 function has_meta(data)
     for i in 6:length(data)
-        data[i] == 0 || continue            # first block end null
-        data[i - 1] == 0 || continue        # second block end null
-        data[i - META_OFFSET_SLEEPSTATE] in 1:2 || continue
+        data[i] == 0 || continue                            # first block end null
+        data[i - 1] == 0 || continue                        # second block end null
+        data[i - META_OFFSET_SLEEPSTATE] in 1:3 || continue # 1 for not sleeping, 2 for sleeping, 3 for task profiler fake state
         data[i - META_OFFSET_CPUCYCLECLOCK] != 0 || continue
         data[i - META_OFFSET_TASKID] != 0 || continue
         data[i - META_OFFSET_THREADID] != 0 || continue
@@ -562,9 +581,9 @@ Julia, and examine the resulting `*.mem` files.
 clear_malloc_data() = ccall(:jl_clear_malloc_data, Cvoid, ())
 
 # C wrappers
-function start_timer()
+function start_timer(all_tasks::Bool=false)
     check_init() # if the profile buffer hasn't been initialized, initialize with default size
-    status = ccall(:jl_profile_start_timer, Cint, ())
+    status = ccall(:jl_profile_start_timer, Cint, (Bool,), all_tasks)
     if status < 0
         error(error_codes[status])
     end
@@ -676,12 +695,16 @@ function parse_flat(::Type{T}, data::Vector{UInt64}, lidict::Union{LineInfoDict,
     startframe = length(data)
     skip = false
     nsleeping = 0
+    task_profiler = false
     for i in startframe:-1:1
         (startframe - 1) >= i >= (startframe - (nmeta + 1)) && continue # skip metadata (its read ahead below) and extra block end NULL IP
         ip = data[i]
         if is_block_end(data, i)
             # read metadata
-            thread_sleeping = data[i - META_OFFSET_SLEEPSTATE] - 1 # subtract 1 as state is incremented to avoid being equal to 0
+            thread_sleeping_state = data[i - META_OFFSET_SLEEPSTATE] - 1 # subtract 1 as state is incremented to avoid being equal to 0
+            if thread_sleeping_state == 2
+                task_profiler = true
+            end
             # cpu_cycle_clock = data[i - META_OFFSET_CPUCYCLECLOCK]
             taskid = data[i - META_OFFSET_TASKID]
             threadid = data[i - META_OFFSET_THREADID]
@@ -689,7 +712,7 @@ function parse_flat(::Type{T}, data::Vector{UInt64}, lidict::Union{LineInfoDict,
                 skip = true
                 continue
             end
-            if thread_sleeping == 1
+            if thread_sleeping_state == 1
                 nsleeping += 1
             end
             skip = false
@@ -723,12 +746,12 @@ function parse_flat(::Type{T}, data::Vector{UInt64}, lidict::Union{LineInfoDict,
         end
     end
     @assert length(lilist) == length(n) == length(m) == length(lilist_idx)
-    return (lilist, n, m, totalshots, nsleeping)
+    return (lilist, n, m, totalshots, nsleeping, task_profiler)
 end
 
 function flat(io::IO, data::Vector{UInt64}, lidict::Union{LineInfoDict, LineInfoFlatDict}, cols::Int, fmt::ProfileFormat,
                 threads::Union{Int,AbstractVector{Int}}, tasks::Union{UInt,AbstractVector{UInt}}, is_subsection::Bool)
-    lilist, n, m, totalshots, nsleeping = parse_flat(fmt.combine ? StackFrame : UInt64, data, lidict, fmt.C, threads, tasks)
+    lilist, n, m, totalshots, nsleeping, task_profiler = parse_flat(fmt.combine ? StackFrame : UInt64, data, lidict, fmt.C, threads, tasks)
     if false # optional: drop the "non-interpretable" ones
         keep = map(frame -> frame != UNKNOWN && frame.line != 0, lilist)
         lilist = lilist[keep]
@@ -748,11 +771,15 @@ function flat(io::IO, data::Vector{UInt64}, lidict::Union{LineInfoDict, LineInfo
         return true
     end
     is_subsection || print_flat(io, lilist, n, m, cols, filenamemap, fmt)
-    Base.print(io, "Total snapshots: ", totalshots, ". Utilization: ", round(Int, util_perc), "%")
+    if task_profiler
+        Base.print(io, "Total snapshots: ", totalshots, "\n")
+    else
+        Base.print(io, "Total snapshots: ", totalshots, ". Utilization: ", round(Int, util_perc), "%")
+    end
     if is_subsection
         println(io)
         print_flat(io, lilist, n, m, cols, filenamemap, fmt)
-    else
+    elseif !task_profiler
         Base.print(io, " across all threads and tasks. Use the `groupby` kwarg to break down by thread and/or task.\n")
     end
     return false
@@ -927,12 +954,16 @@ function tree!(root::StackFrameTree{T}, all::Vector{UInt64}, lidict::Union{LineI
     startframe = length(all)
     skip = false
     nsleeping = 0
+    task_profiler = false
     for i in startframe:-1:1
         (startframe - 1) >= i >= (startframe - (nmeta + 1)) && continue # skip metadata (it's read ahead below) and extra block end NULL IP
         ip = all[i]
         if is_block_end(all, i)
             # read metadata
-            thread_sleeping = all[i - META_OFFSET_SLEEPSTATE] - 1 # subtract 1 as state is incremented to avoid being equal to 0
+            thread_sleeping_state = all[i - META_OFFSET_SLEEPSTATE] - 1 # subtract 1 as state is incremented to avoid being equal to 0
+            if thread_sleeping_state == 2
+                task_profiler = true
+            end
             # cpu_cycle_clock = all[i - META_OFFSET_CPUCYCLECLOCK]
             taskid = all[i - META_OFFSET_TASKID]
             threadid = all[i - META_OFFSET_THREADID]
@@ -941,7 +972,7 @@ function tree!(root::StackFrameTree{T}, all::Vector{UInt64}, lidict::Union{LineI
                 skip = true
                 continue
             end
-            if thread_sleeping == 1
+            if thread_sleeping_state == 1
                 nsleeping += 1
             end
             skip = false
@@ -1047,7 +1078,7 @@ function tree!(root::StackFrameTree{T}, all::Vector{UInt64}, lidict::Union{LineI
         nothing
     end
     cleanup!(root)
-    return root, nsleeping
+    return root, nsleeping, task_profiler
 end
 
 function maxstats(root::StackFrameTree)
@@ -1116,9 +1147,9 @@ end
 function tree(io::IO, data::Vector{UInt64}, lidict::Union{LineInfoFlatDict, LineInfoDict}, cols::Int, fmt::ProfileFormat,
                 threads::Union{Int,AbstractVector{Int}}, tasks::Union{UInt,AbstractVector{UInt}}, is_subsection::Bool)
     if fmt.combine
-        root, nsleeping = tree!(StackFrameTree{StackFrame}(), data, lidict, fmt.C, fmt.recur, threads, tasks)
+        root, nsleeping, task_profiler = tree!(StackFrameTree{StackFrame}(), data, lidict, fmt.C, fmt.recur, threads, tasks)
     else
-        root, nsleeping = tree!(StackFrameTree{UInt64}(), data, lidict, fmt.C, fmt.recur, threads, tasks)
+        root, nsleeping, task_profiler = tree!(StackFrameTree{UInt64}(), data, lidict, fmt.C, fmt.recur, threads, tasks)
     end
     util_perc = (1 - (nsleeping / root.count)) * 100
     is_subsection || print_tree(io, root, cols, fmt, is_subsection)
@@ -1132,11 +1163,15 @@ function tree(io::IO, data::Vector{UInt64}, lidict::Union{LineInfoFlatDict, Line
         end
         return true
     end
-    Base.print(io, "Total snapshots: ", root.count, ". Utilization: ", round(Int, util_perc), "%")
+    if task_profiler
+        Base.print(io, "Total snapshots: ", root.count, "\n")
+    else
+        Base.print(io, "Total snapshots: ", root.count, ". Utilization: ", round(Int, util_perc), "%")
+    end
     if is_subsection
         Base.println(io)
         print_tree(io, root, cols, fmt, is_subsection)
-    else
+    elseif !task_profiler
         Base.print(io, " across all threads and tasks. Use the `groupby` kwarg to break down by thread and/or task.\n")
     end
     return false


### PR DESCRIPTION
## PR Description

Extends @nickrobinson251's https://github.com/RelationalAI/julia/pull/177.

Needs further testing to check whether the output produced on Linux/MacOS makes sense.

There are a few code changes which are vestigial from the time I was thinking about adding a `ptls` for the signal listener thread -- but figured this was not needed after discussing with @kpamnany.

## MWE

```Julia
using Base.Threads

function main()
    s = Threads.Atomic{Float64}(0)
    Threads.@sync begin
        Threads.@spawn begin
            for _ in 1:1_000
                Threads.atomic_add!(s, maximum(randn(1_000_000)))
            end
        end
    end
    return s
end

using Profile
@profile_all main()
Profile.print()
```

## Example Output on Linux (--threads=8)

```
Overhead ╎ [+additional indent] Count File:Line; Function
=========================================================
   ╎173  @Base/Base.jl:609; (::Base.var"#1056#1057")()
   ╎ 173  @Base/Base.jl:572; profile_printing_listener()
   ╎  173  @Base/asyncevent.jl:159; wait
   ╎   173  @Base/asyncevent.jl:142; _trywait(t::Base.AsyncCondition)
   ╎    173  @Base/condition.jl:125; wait
   ╎     173  @Base/condition.jl:130; wait(c::Base.GenericCondition{SpinLock}; …
   ╎    ╎ 173  @Base/task.jl:994; wait()
173╎    ╎  173  @Base/task.jl:985; poptask(W::Base.IntrusiveLinkedListSynchroni…
   ╎422  @Base/client.jl:552; _start()
   ╎ 422  @Base/client.jl:318; exec_options(opts::Base.JLOptions)
   ╎  422  @Base/Base.jl:495; include(mod::Module, _path::String)
   ╎   422  @Base/loading.jl:2144; _include(mapexpr::Function, mod::Module, _pa…
   ╎    422  @Base/loading.jl:2084; include_string(mapexpr::typeof(identity), m…
  2╎     422  @Base/boot.jl:385; eval
   ╎    ╎ 420  …ia-RAI/quick_test.jl:5; main()
   ╎    ╎  420  @Base/task.jl:480; macro expansion
   ╎    ╎   420  @Base/task.jl:407; sync_end(c::Channel{Any})
   ╎    ╎    420  @Base/task.jl:310; _wait(t::Task)
   ╎    ╎     420  @Base/condition.jl:125; wait
   ╎    ╎    ╎ 420  @Base/condition.jl:130; wait(c::Base.GenericCondition{SpinL…
   ╎    ╎    ╎  420  @Base/task.jl:995; wait()
420╎    ╎    ╎   420  @Base/task.jl:921; try_yieldto(undo::typeof(Base.ensure_r…
   ╎3    …compiler/typeinfer.jl:1078; typeinf_ext_toplevel(mi::Core.MethodInsta…
   ╎ 3    …compiler/typeinfer.jl:1082; typeinf_ext_toplevel(interp::Core.Compil…
   ╎  3    …compiler/typeinfer.jl:1051; typeinf_ext(interp::Core.Compiler.Nativ…
   ╎   3    …compiler/typeinfer.jl:216; typeinf(interp::Core.Compiler.NativeInt…
   ╎    3    …ompiler/typeinfer.jl:247; _typeinf(interp::Core.Compiler.NativeIn…
   ╎     3    …ctinterpretation.jl:3186; typeinf_nocycle(interp::Core.Compiler.…
   ╎    ╎ 3    …ctinterpretation.jl:3098; typeinf_local(interp::Core.Compiler.N…
   ╎    ╎  3    …ctinterpretation.jl:2913; abstract_eval_basic_statement(interp…
   ╎    ╎   3    …tinterpretation.jl:2624; abstract_eval_statement(interp::Core…
   ╎    ╎    3    …tinterpretation.jl:2380; abstract_eval_statement_expr(interp…
   ╎    ╎     3    …interpretation.jl:2370; abstract_eval_call(interp::Core.Com…
   ╎    ╎    ╎ 3    …interpretation.jl:2354; abstract_call(interp::Core.Compile…
   ╎    ╎    ╎  3    …interpretation.jl:2162; abstract_call(interp::Core.Compil…
   ╎    ╎    ╎   3    …nterpretation.jl:2169; abstract_call(interp::Core.Compil…
   ╎    ╎    ╎    3    …nterpretation.jl:2087; abstract_call_known(interp::Core…
   ╎    ╎    ╎     3    …nterpretation.jl:95; abstract_call_gf_by_type(interp::…
   ╎    ╎    ╎    ╎ 3    …terpretation.jl:629; abstract_call_method(interp::Cor…
   ╎    ╎    ╎    ╎  3    …er/typeinfer.jl:930; typeinf_edge(interp::Core.Compi…
   ╎    ╎    ╎    ╎   3    …er/typeinfer.jl:216; typeinf(interp::Core.Compiler.…
   ╎    ╎    ╎    ╎    3    …r/typeinfer.jl:247; _typeinf(interp::Core.Compiler…
   ╎    ╎    ╎    ╎     3    …rpretation.jl:3186; typeinf_nocycle(interp::Core.…
   ╎    ╎    ╎    ╎    ╎ 3    …rpretation.jl:3098; typeinf_local(interp::Core.C…
   ╎    ╎    ╎    ╎    ╎  3    …rpretation.jl:2913; abstract_eval_basic_stateme…
   ╎    ╎    ╎    ╎    ╎   3    …pretation.jl:2624; abstract_eval_statement(int…
   ╎    ╎    ╎    ╎    ╎    3    …pretation.jl:2380; abstract_eval_statement_ex…
   ╎    ╎    ╎    ╎    ╎     3    …retation.jl:2370; abstract_eval_call(interp:…
   ╎    ╎    ╎    ╎    ╎    ╎ 3    …retation.jl:2354; abstract_call(interp::Cor…
   ╎    ╎    ╎    ╎    ╎    ╎  3    …retation.jl:2162; abstract_call(interp::Co…
   ╎    ╎    ╎    ╎    ╎    ╎   3    …retation.jl:2169; abstract_call(interp::C…
   ╎    ╎    ╎    ╎    ╎    ╎    3    …retation.jl:2004; abstract_call_known(in…
   ╎    ╎    ╎    ╎    ╎    ╎     3    …retation.jl:1612; abstract_apply(interp…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎ 3    …retation.jl:2169; abstract_call(interp…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎  3    …retation.jl:2087; abstract_call_known…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎   3    …retation.jl:95; abstract_call_gf_by_…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    3    …retation.jl:629; abstract_call_meth…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     3    …ypeinfer.jl:930; typeinf_edge(inte…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 3    …ypeinfer.jl:216; typeinf(interp::…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  3    …ypeinfer.jl:247; _typeinf(interp…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   3    …retation.jl:3186; typeinf_nocyc…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    3    …retation.jl:3098; typeinf_loca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     3    …retation.jl:2913; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  +1 3    …retation.jl:2624; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  +2 3    …retation.jl:2380; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  +3 3    …retation.jl:2370; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  +4 3    …retation.jl:2354; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  +5 3    …retation.jl:2162; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  +6 3    …retation.jl:2169; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  +7 3    …retation.jl:2087; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  +8 3    …retation.jl:95; abstract_call…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  +9 3    …retation.jl:629; abstract_cal…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +10 3    …ypeinfer.jl:930; typeinf_edge…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +11 3    …ypeinfer.jl:216; typeinf(inte…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +12 3    …ypeinfer.jl:247; _typeinf(int…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +13 3    …retation.jl:3186; typeinf_noc…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +14 3    …retation.jl:3098; typeinf_loc…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +15 3    …retation.jl:2913; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +16 3    …retation.jl:2624; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +17 3    …retation.jl:2380; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +18 3    …retation.jl:2370; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +19 3    …retation.jl:2354; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +20 3    …retation.jl:2162; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +21 3    …retation.jl:2169; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +22 3    …retation.jl:2087; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +23 3    …retation.jl:95; abstract_call…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +24 3    …retation.jl:629; abstract_cal…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +25 3    …ypeinfer.jl:930; typeinf_edge…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +26 3    …ypeinfer.jl:216; typeinf(inte…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +27 3    …ypeinfer.jl:247; _typeinf(int…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +28 3    …retation.jl:3186; typeinf_noc…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +29 3    …retation.jl:3098; typeinf_loc…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +30 3    …retation.jl:2913; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +31 3    …retation.jl:2624; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +32 3    …retation.jl:2380; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +33 3    …retation.jl:2370; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +34 3    …retation.jl:2354; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +35 3    …retation.jl:2162; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +36 3    …retation.jl:2169; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +37 3    …retation.jl:2087; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +38 3    …retation.jl:95; abstract_call…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +39 3    …retation.jl:629; abstract_cal…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +40 3    …ypeinfer.jl:930; typeinf_edge…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +41 3    …ypeinfer.jl:216; typeinf(inte…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +42 3    …ypeinfer.jl:247; _typeinf(int…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +43 3    …retation.jl:3186; typeinf_noc…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +44 3    …retation.jl:3098; typeinf_loc…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +45 3    …retation.jl:2913; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +46 3    …retation.jl:2624; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +47 3    …retation.jl:2380; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +48 3    …retation.jl:2370; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +49 3    …retation.jl:2354; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +50 3    …retation.jl:2162; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +51 3    …retation.jl:2169; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +52 3    …retation.jl:2087; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +53 3    …retation.jl:95; abstract_call…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +54 3    …retation.jl:629; abstract_cal…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +55 3    …ypeinfer.jl:930; typeinf_edge…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +56 3    …ypeinfer.jl:216; typeinf(inte…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +57 3    …ypeinfer.jl:247; _typeinf(int…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +58 3    …retation.jl:3186; typeinf_noc…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +59 3    …retation.jl:3098; typeinf_loc…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +60 3    …retation.jl:2913; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +61 3    …retation.jl:2624; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +62 3    …retation.jl:2380; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +63 3    …retation.jl:2370; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +64 3    …retation.jl:2354; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +65 3    …retation.jl:2162; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +66 3    …retation.jl:2169; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +67 3    …retation.jl:2087; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +68 3    …retation.jl:95; abstract_call…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +69 3    …retation.jl:629; abstract_cal…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +70 3    …ypeinfer.jl:930; typeinf_edge…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +71 3    …ypeinfer.jl:216; typeinf(inte…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +72 3    …ypeinfer.jl:247; _typeinf(int…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +73 3    …retation.jl:3186; typeinf_noc…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +74 3    …retation.jl:3098; typeinf_loc…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +75 3    …retation.jl:2913; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +76 3    …retation.jl:2624; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +77 3    …retation.jl:2380; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +78 3    …retation.jl:2370; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +79 3    …retation.jl:2354; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +80 3    …retation.jl:2162; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +81 3    …retation.jl:2169; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +82 3    …retation.jl:2087; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +83 3    …retation.jl:95; abstract_call…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +84 3    …retation.jl:629; abstract_cal…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +85 3    …ypeinfer.jl:930; typeinf_edge…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +86 3    …ypeinfer.jl:216; typeinf(inte…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +87 3    …ypeinfer.jl:247; _typeinf(int…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +88 3    …retation.jl:3186; typeinf_noc…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +89 3    …retation.jl:3098; typeinf_loc…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +90 3    …retation.jl:2889; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +91 3    …retation.jl:2624; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +92 3    …retation.jl:2380; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +93 3    …retation.jl:2370; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +94 3    …retation.jl:2354; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +95 3    …retation.jl:2162; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +96 3    …retation.jl:2169; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +97 3    …retation.jl:2087; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +98 3    …retation.jl:95; abstract_call…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +99 3    …retation.jl:629; abstract_cal…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +100 3    …ypeinfer.jl:930; typeinf_edge…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +101 3    …ypeinfer.jl:216; typeinf(inte…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +102 2    …ypeinfer.jl:247; _typeinf(int…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +103 2    …retation.jl:3186; typeinf_noc…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +104 2    …retation.jl:3098; typeinf_loc…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +105 2    …retation.jl:2913; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +106 2    …retation.jl:2624; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +107 2    …retation.jl:2380; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +108 2    …retation.jl:2370; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +109 2    …retation.jl:2354; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +110 2    …retation.jl:2162; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +111 2    …retation.jl:2169; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +112 2    …retation.jl:2087; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +113 2    …retation.jl:95; abstract_call…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +114 2    …retation.jl:629; abstract_cal…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +115 2    …ypeinfer.jl:930; typeinf_edge…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +116 2    …ypeinfer.jl:216; typeinf(inte…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +117 2    …ypeinfer.jl:247; _typeinf(int…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +118 2    …retation.jl:3186; typeinf_noc…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +119 2    …retation.jl:3098; typeinf_loc…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +120 2    …retation.jl:2889; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +121 2    …retation.jl:2624; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +122 2    …retation.jl:2380; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +123 2    …retation.jl:2370; abstract_ev…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +124 2    …retation.jl:2354; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +125 2    …retation.jl:2162; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +126 2    …retation.jl:2169; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +127 2    …retation.jl:2087; abstract_ca…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +128 2    …retation.jl:95; abstract_call…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +129 2    …retation.jl:629; abstract_cal…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +130 1    …ypeinfer.jl:920; typeinf_edge…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +131 1    …ncestate.jl:430; Core.Compile…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +132 1    …tilities.jl:135; retrieve_cod…
  1╎    ╎    ╎    ╎    ╎    ╎    ╎     +133 1    …tilities.jl:123; get_staged(m…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +130 1    …ypeinfer.jl:930; typeinf_edge…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +131 1    …ypeinfer.jl:216; typeinf(inte…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +132 1    …ypeinfer.jl:272; _typeinf(int…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +133 1    …optimize.jl:453; optimize
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +134 1    …optimize.jl:504; run_passes
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +135 1    …optimize.jl:489; run_passes(c…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +136 1    …r/passes.jl:973; sroa_pass!(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +137 1    …r/passes.jl:5; is_known_call(…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +138 1    …optimize.jl:340; argextype
  1╎    ╎    ╎    ╎    ╎    ╎    ╎     +139 1    …optimize.jl:341; argextype(x:…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +102 1    …ypeinfer.jl:272; _typeinf(int…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +103 1    …optimize.jl:453; optimize
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +104 1    …optimize.jl:504; run_passes
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +105 1    …optimize.jl:489; run_passes(c…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +106 1    …inlining.jl:81; ssa_inlining_…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +107 1    …inlining.jl:672; batch_inline…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +108 1    …ssair/ir.jl:641; Core.Compile…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +109 1    …ssair/ir.jl:198; Core.Compile…
  1╎    ╎    ╎    ╎    ╎    ╎    ╎     +110 1    …ase/boot.jl:477; Array
   ╎433  …lia-RAI/quick_test.jl:8; (::var"#1#2"{Atomic{Float64}})()
   ╎ 68   @Base/reducedim.jl:1010; maximum
   ╎  68   @Base/reducedim.jl:1010; #maximum#837
   ╎   68   @Base/reducedim.jl:1014; _maximum
   ╎    68   @Base/reducedim.jl:1014; #_maximum#839
   ╎     68   @Base/reducedim.jl:1015; _maximum
   ╎    ╎ 68   @Base/reducedim.jl:1015; #_maximum#840
   ╎    ╎  68   @Base/reducedim.jl:357; mapreduce
   ╎    ╎   68   @Base/reducedim.jl:357; #mapreduce#822
   ╎    ╎    68   @Base/reducedim.jl:365; _mapreduce_dim
   ╎    ╎     68   @Base/reduce.jl:447; _mapreduce(f::typeof(identity), op::typ…
   ╎    ╎    ╎ 1    @Base/reduce.jl:651; mapreduce_impl(f::typeof(identity), op…
  1╎    ╎    ╎  1    @Base/int.jl:514; <=
   ╎    ╎    ╎ 34   @Base/reduce.jl:653; mapreduce_impl(f::typeof(identity), op…
   ╎    ╎    ╎  34   @Base/reduce.jl:626; _fast
 34╎    ╎    ╎   34   …ase/essentials.jl:647; ifelse
   ╎    ╎    ╎ 7    @Base/reduce.jl:654; mapreduce_impl(f::typeof(identity), op…
   ╎    ╎    ╎  7    @Base/reduce.jl:626; _fast
  6╎    ╎    ╎   6    …ase/essentials.jl:647; ifelse
   ╎    ╎    ╎   1    @Base/float.jl:620; isnan
  1╎    ╎    ╎    1    @Base/float.jl:535; !=
   ╎    ╎    ╎ 26   @Base/reduce.jl:657; mapreduce_impl(f::typeof(identity), op…
   ╎    ╎    ╎  26   @Base/range.jl:901; iterate
 26╎    ╎    ╎   26   @Base/promotion.jl:521; ==
   ╎ 365  @Random/src/normal.jl:258; randn
   ╎  365  @Random/src/normal.jl:252; randn
   ╎   4    @Base/boot.jl:491; Array
  4╎    4    @Base/boot.jl:477; Array
   ╎   172  @Random/src/normal.jl:237; randn!(rng::Random.TaskLocalRNG, A::Vect…
   ╎    172  @Random/src/Random.jl:269; rand!
   ╎     172  @Random/src/Random.jl:269; rand!
   ╎    ╎ 172  …/src/XoshiroSimd.jl:299; rand!
   ╎    ╎  172  …/src/XoshiroSimd.jl:141; xoshiro_bulk
   ╎    ╎   172  …/src/XoshiroSimd.jl:142; xoshiro_bulk
  1╎    ╎    49   …src/XoshiroSimd.jl:248; xoshiro_bulk_simd(rng::Random.TaskLo…
 48╎    ╎     48   @Base/int.jl:514; <=
   ╎    ╎    1    …src/XoshiroSimd.jl:249; xoshiro_bulk_simd(rng::Random.TaskLo…
  1╎    ╎     1    …src/XoshiroSimd.jl:71; _plus
   ╎    ╎    2    …src/XoshiroSimd.jl:250; xoshiro_bulk_simd(rng::Random.TaskLo…
  2╎    ╎     2    …src/XoshiroSimd.jl:65; _shl17
   ╎    ╎    1    …src/XoshiroSimd.jl:252; xoshiro_bulk_simd(rng::Random.TaskLo…
  1╎    ╎     1    …src/XoshiroSimd.jl:77; _xor
   ╎    ╎    3    …src/XoshiroSimd.jl:253; xoshiro_bulk_simd(rng::Random.TaskLo…
  3╎    ╎     3    …src/XoshiroSimd.jl:77; _xor
   ╎    ╎    1    …src/XoshiroSimd.jl:254; xoshiro_bulk_simd(rng::Random.TaskLo…
  1╎    ╎     1    …src/XoshiroSimd.jl:77; _xor
   ╎    ╎    1    …src/XoshiroSimd.jl:256; xoshiro_bulk_simd(rng::Random.TaskLo…
  1╎    ╎     1    …src/XoshiroSimd.jl:55; _rotl45
   ╎    ╎    114  …src/XoshiroSimd.jl:257; xoshiro_bulk_simd(rng::Random.TaskLo…
   ╎    ╎     114  @Base/pointer.jl:146; unsafe_store!
114╎    ╎    ╎ 114  @Base/pointer.jl:146; unsafe_store!
   ╎   164  @Random/src/normal.jl:240; randn!(rng::Random.TaskLocalRNG, A::Vect…
  8╎    8    @Base/array.jl:1021; setindex!
  6╎    6    @Base/essentials.jl:13; getindex
   ╎    34   @Random/src/normal.jl:63; _randn
   ╎     34   @Base/int.jl:534; >>
 34╎    ╎ 34   @Base/int.jl:528; >>
   ╎    57   @Random/src/normal.jl:65; _randn
  1╎     1    @Base/essentials.jl:13; getindex
  3╎     3    @Base/essentials.jl:647; ifelse
 13╎     13   @Base/int.jl:85; -
   ╎     17   @Base/int.jl:627; rem
   ╎    ╎ 17   @Base/operators.jl:276; !=
   ╎    ╎  17   @Base/int.jl:518; ==
 17╎    ╎   17   @Base/promotion.jl:521; ==
   ╎     23   @Base/promotion.jl:423; *
 19╎    ╎ 19   @Base/float.jl:411; *
   ╎    ╎ 4    @Base/promotion.jl:393; promote
   ╎    ╎  4    @Base/promotion.jl:370; _promote
   ╎    ╎   4    @Base/number.jl:7; convert
  4╎    ╎    4    @Base/float.jl:159; Float64
   ╎    18   @Random/src/normal.jl:66; _randn
   ╎     18   @Base/int.jl:519; <
 18╎    ╎ 18   @Base/int.jl:513; <
  1╎    41   @Random/src/normal.jl:67; _randn
  1╎     1    @Base/special/exp.jl:327; exp(x::Float64)
  2╎     2    @Random/src/normal.jl:40; randn(rng::Random.TaskLocalRNG)
  5╎     5    @Random/src/normal.jl:0; randn_unlikely(rng::Random.TaskLocalRNG,…
  2╎     2    @Random/src/normal.jl:72; randn_unlikely(rng::Random.TaskLocalRNG…
   ╎     2    @Random/src/normal.jl:73; randn_unlikely(rng::Random.TaskLocalRNG…
  2╎    ╎ 2    @Base/promotion.jl:521; ==
   ╎     23   @Random/src/normal.jl:80; randn_unlikely(rng::Random.TaskLocalRNG…
  1╎    ╎ 1    @Base/float.jl:411; *
  3╎    ╎ 3    @Base/float.jl:409; +
   ╎    ╎ 17   @Base/special/exp.jl:327; exp(x::Float64)
   ╎    ╎  2    @Base/special/exp.jl:211; exp_impl
  2╎    ╎   2    @Base/float.jl:410; -
   ╎    ╎  1    @Base/special/exp.jl:213; exp_impl
  1╎    ╎   1    @Base/float.jl:414; muladd
   ╎    ╎  3    @Base/special/exp.jl:215; exp_impl
   ╎    ╎   1    @Base/special/exp.jl:181; table_unpack
  1╎    ╎    1    @Base/int.jl:347; &
   ╎    ╎   2    @Base/special/exp.jl:182; table_unpack
   ╎    ╎    2    @Base/int.jl:534; >>
  2╎    ╎     2    @Base/int.jl:528; >>
   ╎    ╎  9    @Base/special/exp.jl:216; exp_impl
  2╎    ╎   2    @Base/float.jl:409; +
   ╎    ╎   7    @Base/special/exp.jl:78; expm1b_kernel
  4╎    ╎    4    @Base/float.jl:411; *
   ╎    ╎    3    @Base/math.jl:186; evalpoly
   ╎    ╎     3    @Base/math.jl:187; macro expansion
  3╎    ╎    ╎ 3    @Base/float.jl:414; muladd
   ╎    ╎  1    @Base/special/exp.jl:218; exp_impl
  1╎    ╎   1    @Base/float.jl:537; <=
   ╎    ╎  1    @Base/special/exp.jl:229; exp_impl
  1╎    ╎   1    @Base/essentials.jl:581; reinterpret
   ╎    ╎ 2    …andom/src/Random.jl:258; rand
   ╎    ╎  2    …andom/src/Random.jl:258; rand
   ╎    ╎   2    …ndom/src/Xoshiro.jl:244; rand
   ╎    ╎    2    …ndom/src/Random.jl:258; rand
   ╎    ╎     1    …dom/src/Xoshiro.jl:146; rand
   ╎    ╎    ╎ 1    @Base/int.jl:536; <<
  1╎    ╎    ╎  1    @Base/int.jl:529; <<
   ╎    ╎     1    …dom/src/Xoshiro.jl:153; rand
  1╎    ╎    ╎ 1    @Base/Base.jl:41; setproperty!
  1╎     5    @Random/src/normal.jl:83; randn_unlikely(rng::Random.TaskLocalRNG…
   ╎    ╎ 2    @Random/src/normal.jl:49; randn(rng::Random.TaskLocalRNG)
   ╎    ╎  2    …andom/src/Random.jl:255; rand
   ╎    ╎   2    …ndom/src/Xoshiro.jl:235; rand
   ╎    ╎    2    …ndom/src/Random.jl:258; rand
   ╎    ╎     1    …dom/src/Xoshiro.jl:143; rand
  1╎    ╎    ╎ 1    @Base/task.jl:182; getproperty
   ╎    ╎     1    …dom/src/Xoshiro.jl:153; rand
  1╎    ╎    ╎ 1    @Base/Base.jl:41; setproperty!
   ╎    ╎ 2    @Random/src/normal.jl:54; randn(rng::Random.TaskLocalRNG)
  1╎    ╎  1    @Base/int.jl:85; -
   ╎    ╎  1    @Base/promotion.jl:423; *
  1╎    ╎   1    @Base/float.jl:411; *
   ╎   20   @Random/src/normal.jl:241; randn!(rng::Random.TaskLocalRNG, A::Vect…
   ╎    20   @Base/range.jl:901; iterate
 20╎     20   @Base/promotion.jl:521; ==
  5╎   5    @Random/src/normal.jl:72; randn_unlikely(rng::Random.TaskLocalRNG, …
Total snapshots: 1816. Utilization: 100% across all threads and tasks. Use the `groupby` kwarg to break down by thread and/or task.
```

## Example Output on MacOS (--threads=8)

```
Overhead ╎ [+additional indent] Count File:Line; Function
=========================================================
   ╎167 …julia-RAI/quick_test.jl:8; (::var"#1#2"{Atomic{Float64}})()
   ╎ 46  @Base/reducedim.jl:1010; maximum
   ╎  46  @Base/reducedim.jl:1010; #maximum#837
   ╎   46  @Base/reducedim.jl:1014; _maximum
   ╎    46  @Base/reducedim.jl:1014; #_maximum#839
   ╎     46  @Base/reducedim.jl:1015; _maximum
   ╎    ╎ 46  @Base/reducedim.jl:1015; #_maximum#840
   ╎    ╎  46  @Base/reducedim.jl:357; mapreduce
   ╎    ╎   46  @Base/reducedim.jl:357; #mapreduce#822
   ╎    ╎    46  @Base/reducedim.jl:365; _mapreduce_dim
   ╎    ╎     46  @Base/reduce.jl:447; _mapreduce(f::typeof(identity), op::type…
   ╎    ╎    ╎ 6   @Base/reduce.jl:654; mapreduce_impl(f::typeof(identity), op:…
   ╎    ╎    ╎  6   @Base/reduce.jl:626; _fast
  6╎    ╎    ╎   6   …ase/essentials.jl:647; ifelse
   ╎    ╎    ╎ 16  @Base/reduce.jl:655; mapreduce_impl(f::typeof(identity), op:…
  1╎    ╎    ╎  1   …ase/essentials.jl:13; getindex
   ╎    ╎    ╎  15  @Base/reduce.jl:626; _fast
 15╎    ╎    ╎   15  …ase/essentials.jl:647; ifelse
   ╎    ╎    ╎ 19  @Base/reduce.jl:656; mapreduce_impl(f::typeof(identity), op:…
   ╎    ╎    ╎  19  @Base/reduce.jl:626; _fast
 19╎    ╎    ╎   19  …ase/essentials.jl:647; ifelse
   ╎    ╎    ╎ 5   @Base/reduce.jl:657; mapreduce_impl(f::typeof(identity), op:…
   ╎    ╎    ╎  5   @Base/range.jl:901; iterate
  5╎    ╎    ╎   5   @Base/promotion.jl:521; ==
   ╎ 121 @Random/src/normal.jl:258; randn
   ╎  121 @Random/src/normal.jl:252; randn
   ╎   55  @Random/src/normal.jl:237; randn!(rng::Random.TaskLocalRNG, A::Vecto…
   ╎    55  @Random/src/Random.jl:269; rand!
   ╎     55  @Random/src/Random.jl:269; rand!
   ╎    ╎ 55  …m/src/XoshiroSimd.jl:299; rand!
   ╎    ╎  55  …/src/XoshiroSimd.jl:141; xoshiro_bulk
   ╎    ╎   55  …/src/XoshiroSimd.jl:142; xoshiro_bulk
   ╎    ╎    9   …/src/XoshiroSimd.jl:249; xoshiro_bulk_simd(rng::Random.TaskLo…
  9╎    ╎     9   …/src/XoshiroSimd.jl:58; _rotl23
   ╎    ╎    3   …/src/XoshiroSimd.jl:250; xoshiro_bulk_simd(rng::Random.TaskLo…
  3╎    ╎     3   …/src/XoshiroSimd.jl:65; _shl17
   ╎    ╎    3   …/src/XoshiroSimd.jl:252; xoshiro_bulk_simd(rng::Random.TaskLo…
  3╎    ╎     3   …/src/XoshiroSimd.jl:77; _xor
   ╎    ╎    1   …/src/XoshiroSimd.jl:253; xoshiro_bulk_simd(rng::Random.TaskLo…
  1╎    ╎     1   …/src/XoshiroSimd.jl:77; _xor
   ╎    ╎    1   …/src/XoshiroSimd.jl:255; xoshiro_bulk_simd(rng::Random.TaskLo…
  1╎    ╎     1   …/src/XoshiroSimd.jl:77; _xor
   ╎    ╎    12  …/src/XoshiroSimd.jl:256; xoshiro_bulk_simd(rng::Random.TaskLo…
 12╎    ╎     12  …/src/XoshiroSimd.jl:55; _rotl45
   ╎    ╎    26  …/src/XoshiroSimd.jl:257; xoshiro_bulk_simd(rng::Random.TaskLo…
   ╎    ╎     26  @Base/pointer.jl:146; unsafe_store!
 26╎    ╎    ╎ 26  @Base/pointer.jl:146; unsafe_store!
   ╎   66  @Random/src/normal.jl:240; randn!(rng::Random.TaskLocalRNG, A::Vecto…
 10╎    10  @Base/array.jl:1021; setindex!
  3╎    29  @Random/src/normal.jl:66; _randn
 26╎     26  @Base/essentials.jl:13; getindex
  9╎    27  @Random/src/normal.jl:67; _randn
  8╎     8   @Random/src/normal.jl:0; randn_unlikely(rng::Random.TaskLocalRNG, …
   ╎     1   @Random/src/normal.jl:76; randn_unlikely(rng::Random.TaskLocalRNG,…
   ╎    ╎ 1   @Random/src/Random.jl:258; rand
   ╎    ╎  1   …andom/src/Random.jl:258; rand
   ╎    ╎   1   …ndom/src/Xoshiro.jl:244; rand
  1╎    ╎    1   @Base/float.jl:165; Float64
  1╎     1   @Random/src/normal.jl:80; randn_unlikely(rng::Random.TaskLocalRNG,…
  5╎     8   @Random/src/normal.jl:83; randn_unlikely(rng::Random.TaskLocalRNG,…
   ╎    ╎ 1   @Random/src/normal.jl:49; randn(rng::Random.TaskLocalRNG)
   ╎    ╎  1   …andom/src/Random.jl:255; rand
   ╎    ╎   1   …ndom/src/Xoshiro.jl:235; rand
   ╎    ╎    1   …andom/src/Random.jl:258; rand
   ╎    ╎     1   …dom/src/Xoshiro.jl:153; rand
  1╎    ╎    ╎ 1   @Base/Base.jl:41; setproperty!
   ╎    ╎ 1   @Random/src/normal.jl:54; randn(rng::Random.TaskLocalRNG)
   ╎    ╎  1   @Base/promotion.jl:423; *
   ╎    ╎   1   @Base/promotion.jl:393; promote
   ╎    ╎    1   @Base/promotion.jl:370; _promote
   ╎    ╎     1   @Base/number.jl:7; convert
  1╎    ╎    ╎ 1   @Base/float.jl:159; Float64
   ╎    ╎ 1   @Random/src/normal.jl:56; randn(rng::Random.TaskLocalRNG)
  1╎    ╎  1   @Random/src/normal.jl:0; randn_unlikely(rng::Random.TaskLocalRNG…
   ╎4   …usr/lib/julia/sys.dylib:?; typeinf_ext_toplevel(mi::Core.MethodInstanc…
   ╎ 4   …usr/lib/julia/sys.dylib:?; typeinf_ext_toplevel(interp::Core.Compiler…
   ╎  4   …compiler/typeinfer.jl:1051; typeinf_ext(interp::Core.Compiler.Native…
   ╎   4   …sr/lib/julia/sys.dylib:?; typeinf(interp::Core.Compiler.NativeInter…
   ╎    4   …r/lib/julia/sys.dylib:?; _typeinf(interp::Core.Compiler.NativeInte…
   ╎     4   …r/lib/julia/sys.dylib:?; typeinf_nocycle(interp::Core.Compiler.Na…
   ╎    ╎ 4   …r/lib/julia/sys.dylib:?; typeinf_local(interp::Core.Compiler.Nat…
   ╎    ╎  4   …/lib/julia/sys.dylib:?; abstract_eval_basic_statement(interp::C…
   ╎    ╎   4   …/lib/julia/sys.dylib:?; abstract_eval_statement(interp::Core.C…
   ╎    ╎    4   …lib/julia/sys.dylib:?; abstract_eval_statement_expr(interp::C…
   ╎    ╎     4   …lib/julia/sys.dylib:?; abstract_eval_call(interp::Core.Compi…
   ╎    ╎    ╎ 4   …lib/julia/sys.dylib:?; abstract_call(interp::Core.Compiler.…
   ╎    ╎    ╎  4   …ib/julia/sys.dylib:?; abstract_call(interp::Core.Compiler.…
   ╎    ╎    ╎   4   …interpretation.jl:2169; abstract_call(interp::Core.Compil…
   ╎    ╎    ╎    4   …b/julia/sys.dylib:?; abstract_call_known(interp::Core.Co…
   ╎    ╎    ╎     4   …interpretation.jl:95; abstract_call_gf_by_type(interp::…
   ╎    ╎    ╎    ╎ 4   …nterpretation.jl:629; abstract_call_method(interp::Cor…
   ╎    ╎    ╎    ╎  4   …er/typeinfer.jl:930; typeinf_edge(interp::Core.Compil…
   ╎    ╎    ╎    ╎   4   …/julia/sys.dylib:?; typeinf(interp::Core.Compiler.Na…
   ╎    ╎    ╎    ╎    4   …julia/sys.dylib:?; _typeinf(interp::Core.Compiler.N…
   ╎    ╎    ╎    ╎     4   …julia/sys.dylib:?; typeinf_nocycle(interp::Core.Co…
   ╎    ╎    ╎    ╎    ╎ 4   …julia/sys.dylib:?; typeinf_local(interp::Core.Com…
   ╎    ╎    ╎    ╎    ╎  4   …ulia/sys.dylib:?; abstract_eval_basic_statement(…
   ╎    ╎    ╎    ╎    ╎   4   …ulia/sys.dylib:?; abstract_eval_statement(inter…
   ╎    ╎    ╎    ╎    ╎    4   …lia/sys.dylib:?; abstract_eval_statement_expr(…
   ╎    ╎    ╎    ╎    ╎     4   …lia/sys.dylib:?; abstract_eval_call(interp::C…
   ╎    ╎    ╎    ╎    ╎    ╎ 4   …lia/sys.dylib:?; abstract_call(interp::Core.…
   ╎    ╎    ╎    ╎    ╎    ╎  4   …ia/sys.dylib:?; abstract_call(interp::Core.…
   ╎    ╎    ╎    ╎    ╎    ╎   4   …retation.jl:2169; abstract_call(interp::Co…
   ╎    ╎    ╎    ╎    ╎    ╎    4   …a/sys.dylib:?; abstract_call_known(interp…
   ╎    ╎    ╎    ╎    ╎    ╎     3   …retation.jl:1612; abstract_apply(interp:…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎ 3   …retation.jl:2169; abstract_call(interp:…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎  3   …a/sys.dylib:?; abstract_call_known(int…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎   3   …retation.jl:95; abstract_call_gf_by_t…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    3   …retation.jl:629; abstract_call_metho…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     3   …ypeinfer.jl:930; typeinf_edge(inter…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 3   …a/sys.dylib:?; typeinf(interp::Cor…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  3   …a/sys.dylib:?; _typeinf(interp::C…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   3   …a/sys.dylib:?; typeinf_nocycle(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    3   …a/sys.dylib:?; typeinf_local(in…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     3   …a/sys.dylib:?; abstract_eval_b…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  +1 3   …a/sys.dylib:?; abstract_eval_s…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  +2 3   …a/sys.dylib:?; abstract_eval_s…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  +3 3   …a/sys.dylib:?; abstract_eval_c…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  +4 3   …a/sys.dylib:?; abstract_call(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  +5 3   …a/sys.dylib:?; abstract_call(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  +6 3   …retation.jl:2169; abstract_cal…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  +7 3   …a/sys.dylib:?; abstract_call_k…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  +8 3   …retation.jl:95; abstract_call_…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  +9 3   …retation.jl:629; abstract_call…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +10 3   …ypeinfer.jl:930; typeinf_edge(…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +11 3   …a/sys.dylib:?; typeinf(interp:…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +12 3   …a/sys.dylib:?; _typeinf(interp…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +13 3   …a/sys.dylib:?; typeinf_nocycle…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +14 3   …a/sys.dylib:?; typeinf_local(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +15 3   …a/sys.dylib:?; abstract_eval_b…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +16 3   …a/sys.dylib:?; abstract_eval_s…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +17 3   …a/sys.dylib:?; abstract_eval_s…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +18 3   …a/sys.dylib:?; abstract_eval_c…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +19 3   …a/sys.dylib:?; abstract_call(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +20 3   …a/sys.dylib:?; abstract_call(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +21 3   …retation.jl:2169; abstract_cal…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +22 3   …a/sys.dylib:?; abstract_call_k…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +23 3   …retation.jl:95; abstract_call_…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +24 3   …retation.jl:629; abstract_call…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +25 3   …ypeinfer.jl:930; typeinf_edge(…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +26 3   …a/sys.dylib:?; typeinf(interp:…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +27 3   …a/sys.dylib:?; _typeinf(interp…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +28 3   …a/sys.dylib:?; typeinf_nocycle…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +29 3   …a/sys.dylib:?; typeinf_local(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +30 3   …a/sys.dylib:?; abstract_eval_b…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +31 3   …a/sys.dylib:?; abstract_eval_s…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +32 3   …a/sys.dylib:?; abstract_eval_s…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +33 3   …a/sys.dylib:?; abstract_eval_c…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +34 3   …a/sys.dylib:?; abstract_call(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +35 3   …a/sys.dylib:?; abstract_call(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +36 3   …retation.jl:2169; abstract_cal…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +37 3   …a/sys.dylib:?; abstract_call_k…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +38 3   …retation.jl:95; abstract_call_…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +39 3   …retation.jl:629; abstract_call…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +40 3   …ypeinfer.jl:930; typeinf_edge(…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +41 3   …a/sys.dylib:?; typeinf(interp:…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +42 3   …a/sys.dylib:?; _typeinf(interp…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +43 3   …a/sys.dylib:?; typeinf_nocycle…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +44 3   …a/sys.dylib:?; typeinf_local(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +45 3   …a/sys.dylib:?; abstract_eval_b…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +46 3   …a/sys.dylib:?; abstract_eval_s…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +47 3   …a/sys.dylib:?; abstract_eval_s…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +48 3   …a/sys.dylib:?; abstract_eval_c…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +49 3   …a/sys.dylib:?; abstract_call(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +50 3   …a/sys.dylib:?; abstract_call(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +51 3   …retation.jl:2169; abstract_cal…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +52 3   …a/sys.dylib:?; abstract_call_k…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +53 3   …retation.jl:95; abstract_call_…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +54 3   …retation.jl:629; abstract_call…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +55 3   …ypeinfer.jl:930; typeinf_edge(…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +56 3   …a/sys.dylib:?; typeinf(interp:…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +57 3   …a/sys.dylib:?; _typeinf(interp…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +58 3   …a/sys.dylib:?; typeinf_nocycle…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +59 3   …a/sys.dylib:?; typeinf_local(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +60 3   …a/sys.dylib:?; abstract_eval_b…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +61 3   …a/sys.dylib:?; abstract_eval_s…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +62 3   …a/sys.dylib:?; abstract_eval_s…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +63 3   …a/sys.dylib:?; abstract_eval_c…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +64 3   …a/sys.dylib:?; abstract_call(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +65 3   …a/sys.dylib:?; abstract_call(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +66 3   …retation.jl:2169; abstract_cal…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +67 3   …a/sys.dylib:?; abstract_call_k…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +68 3   …retation.jl:95; abstract_call_…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +69 3   …retation.jl:629; abstract_call…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +70 3   …ypeinfer.jl:930; typeinf_edge(…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +71 3   …a/sys.dylib:?; typeinf(interp:…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +72 3   …a/sys.dylib:?; _typeinf(interp…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +73 3   …a/sys.dylib:?; typeinf_nocycle…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +74 3   …a/sys.dylib:?; typeinf_local(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +75 3   …a/sys.dylib:?; abstract_eval_b…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +76 3   …a/sys.dylib:?; abstract_eval_s…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +77 3   …a/sys.dylib:?; abstract_eval_s…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +78 3   …a/sys.dylib:?; abstract_eval_c…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +79 3   …a/sys.dylib:?; abstract_call(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +80 3   …a/sys.dylib:?; abstract_call(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +81 3   …retation.jl:2169; abstract_cal…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +82 3   …a/sys.dylib:?; abstract_call_k…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +83 3   …retation.jl:95; abstract_call_…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +84 3   …retation.jl:629; abstract_call…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +85 3   …ypeinfer.jl:930; typeinf_edge(…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +86 3   …a/sys.dylib:?; typeinf(interp:…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +87 3   …a/sys.dylib:?; _typeinf(interp…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +88 3   …a/sys.dylib:?; typeinf_nocycle…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +89 3   …a/sys.dylib:?; typeinf_local(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +90 3   …a/sys.dylib:?; abstract_eval_b…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +91 3   …a/sys.dylib:?; abstract_eval_s…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +92 3   …a/sys.dylib:?; abstract_eval_s…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +93 3   …a/sys.dylib:?; abstract_eval_c…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +94 3   …a/sys.dylib:?; abstract_call(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +95 3   …a/sys.dylib:?; abstract_call(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +96 3   …retation.jl:2169; abstract_cal…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +97 3   …a/sys.dylib:?; abstract_call_k…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +98 3   …retation.jl:95; abstract_call_…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +99 3   …retation.jl:629; abstract_call…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +100 3   …ypeinfer.jl:930; typeinf_edge(…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +101 3   …a/sys.dylib:?; typeinf(interp:…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +102 3   …a/sys.dylib:?; _typeinf(interp…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +103 3   …a/sys.dylib:?; typeinf_nocycle…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +104 3   …a/sys.dylib:?; typeinf_local(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +105 3   …a/sys.dylib:?; abstract_eval_b…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +106 3   …a/sys.dylib:?; abstract_eval_s…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +107 3   …a/sys.dylib:?; abstract_eval_s…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +108 3   …a/sys.dylib:?; abstract_eval_c…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +109 3   …a/sys.dylib:?; abstract_call(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +110 3   …a/sys.dylib:?; abstract_call(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +111 3   …retation.jl:2169; abstract_cal…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +112 3   …a/sys.dylib:?; abstract_call_k…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +113 3   …retation.jl:95; abstract_call_…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +114 3   …retation.jl:629; abstract_call…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +115 3   …ypeinfer.jl:930; typeinf_edge(…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +116 3   …a/sys.dylib:?; typeinf(interp:…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +117 3   …a/sys.dylib:?; _typeinf(interp…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +118 3   …a/sys.dylib:?; typeinf_nocycle…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +119 3   …a/sys.dylib:?; typeinf_local(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +120 3   …a/sys.dylib:?; abstract_eval_b…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +121 3   …a/sys.dylib:?; abstract_eval_s…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +122 3   …a/sys.dylib:?; abstract_eval_s…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +123 3   …a/sys.dylib:?; abstract_eval_c…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +124 3   …a/sys.dylib:?; abstract_call(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +125 3   …a/sys.dylib:?; abstract_call(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +126 3   …retation.jl:2169; abstract_cal…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +127 3   …a/sys.dylib:?; abstract_call_k…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +128 3   …retation.jl:95; abstract_call_…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +129 3   …retation.jl:629; abstract_call…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +130 1   …ypeinfer.jl:920; typeinf_edge(…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +131 1   …a/sys.dylib:?; Core.Compiler.I…
  1╎    ╎    ╎    ╎    ╎    ╎    ╎     +132 1   …a/sys.dylib:?; get_staged(mi::…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +130 2   …ypeinfer.jl:930; typeinf_edge(…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +131 2   …a/sys.dylib:?; typeinf(interp:…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +132 2   …a/sys.dylib:?; _typeinf(interp…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +133 1   …a/sys.dylib:?; run_passes(ci::…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +134 1   …a/sys.dylib:?; adce_pass!(ir::…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +135 1   …a/sys.dylib:?; iterate_compact…
  1╎    ╎    ╎    ╎    ╎    ╎    ╎     +136 1   …a/sys.dylib:?; process_node!(c…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +133 1   …a/sys.dylib:?; typeinf_nocycle…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +134 1   …a/sys.dylib:?; typeinf_local(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +135 1   …a/sys.dylib:?; abstract_eval_b…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +136 1   …a/sys.dylib:?; abstract_eval_s…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +137 1   …a/sys.dylib:?; abstract_eval_s…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +138 1   …a/sys.dylib:?; abstract_eval_c…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +139 1   …a/sys.dylib:?; abstract_call(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +140 1   …a/sys.dylib:?; abstract_call(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +141 1   …retation.jl:2169; abstract_cal…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +142 1   …a/sys.dylib:?; abstract_call_k…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +143 1   …retation.jl:103; abstract_call…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +144 1   …a/sys.dylib:?; abstract_call_m…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +145 1   …a/sys.dylib:?; abstract_call_m…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +146 1   …retation.jl:1207; const_prop_c…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +147 1   …a/sys.dylib:?; typeinf(interp:…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +148 1   …a/sys.dylib:?; _typeinf(interp…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +149 1   …a/sys.dylib:?; finish(interp::…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     +150 1   …a/sys.dylib:?; inline_cost(ir:…
  1╎    ╎    ╎    ╎    ╎    ╎    ╎     +151 1   …a/sys.dylib:?; statement_cost(…
   ╎    ╎    ╎    ╎    ╎    ╎     1   …retation.jl:95; abstract_call_gf_by_type…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1   …retation.jl:629; abstract_call_method(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎  1   …ypeinfer.jl:930; typeinf_edge(interp::…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎   1   …a/sys.dylib:?; typeinf(interp::Core.C…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    1   …a/sys.dylib:?; _typeinf(interp::Core…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎     1   …a/sys.dylib:?; typeinf_nocycle(inte…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1   …a/sys.dylib:?; typeinf_local(inter…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1   …a/sys.dylib:?; abstract_eval_basi…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1   …a/sys.dylib:?; abstract_eval_sta…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1   …a/sys.dylib:?; abstract_eval_st…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1   …a/sys.dylib:?; abstract_eval_c…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  +1 1   …a/sys.dylib:?; abstract_call(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  +2 1   …a/sys.dylib:?; abstract_call(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  +3 1   …retation.jl:2169; abstract_cal…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  +4 1   …a/sys.dylib:?; abstract_call_k…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  +5 1   …retation.jl:95; abstract_call_…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  +6 1   …retation.jl:629; abstract_call…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  +7 1   …ypeinfer.jl:930; typeinf_edge(…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  +8 1   …a/sys.dylib:?; typeinf(interp:…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  +9 1   …a/sys.dylib:?; _typeinf(interp…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +10 1   …a/sys.dylib:?; typeinf_nocycle…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +11 1   …a/sys.dylib:?; typeinf_local(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +12 1   …a/sys.dylib:?; abstract_eval_b…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +13 1   …a/sys.dylib:?; abstract_eval_s…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +14 1   …a/sys.dylib:?; abstract_eval_s…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +15 1   …a/sys.dylib:?; abstract_eval_c…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +16 1   …a/sys.dylib:?; abstract_call(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +17 1   …a/sys.dylib:?; abstract_call(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +18 1   …retation.jl:2169; abstract_cal…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +19 1   …a/sys.dylib:?; abstract_call_k…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +20 1   …retation.jl:95; abstract_call_…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +21 1   …retation.jl:629; abstract_call…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +22 1   …ypeinfer.jl:930; typeinf_edge(…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +23 1   …a/sys.dylib:?; typeinf(interp:…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +24 1   …a/sys.dylib:?; _typeinf(interp…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +25 1   …a/sys.dylib:?; typeinf_nocycle…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +26 1   …a/sys.dylib:?; typeinf_local(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +27 1   …a/sys.dylib:?; abstract_eval_b…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +28 1   …a/sys.dylib:?; abstract_eval_s…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +29 1   …a/sys.dylib:?; abstract_eval_s…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +30 1   …a/sys.dylib:?; abstract_eval_c…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +31 1   …a/sys.dylib:?; abstract_call(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +32 1   …a/sys.dylib:?; abstract_call(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +33 1   …retation.jl:2169; abstract_cal…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +34 1   …a/sys.dylib:?; abstract_call_k…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +35 1   …retation.jl:95; abstract_call_…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +36 1   …retation.jl:629; abstract_call…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +37 1   …ypeinfer.jl:930; typeinf_edge(…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +38 1   …a/sys.dylib:?; typeinf(interp:…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +39 1   …a/sys.dylib:?; _typeinf(interp…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +40 1   …a/sys.dylib:?; typeinf_nocycle…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +41 1   …a/sys.dylib:?; typeinf_local(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +42 1   …a/sys.dylib:?; abstract_eval_b…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +43 1   …a/sys.dylib:?; abstract_eval_s…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +44 1   …a/sys.dylib:?; abstract_eval_s…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +45 1   …a/sys.dylib:?; abstract_eval_c…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +46 1   …a/sys.dylib:?; abstract_call(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +47 1   …a/sys.dylib:?; abstract_call(i…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +48 1   …retation.jl:2169; abstract_cal…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +49 1   …a/sys.dylib:?; abstract_call_k…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +50 1   …retation.jl:24; abstract_call_…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +51 1   …a/sys.dylib:?; find_matching_m…
   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +52 1   …a/sys.dylib:?; findall(sig::Ty…
  1╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ +53 1   …a/sys.dylib:?; _methods_by_fty…
   ╎5   @Random/src/normal.jl:80; randn_unlikely(rng::Random.TaskLocalRNG, idx:…
   ╎ 5   @Base/special/exp.jl:327; exp(x::Float64)
   ╎  2   @Base/special/exp.jl:215; exp_impl
   ╎   2   @Base/special/exp.jl:181; table_unpack
  2╎    2   @Base/int.jl:347; &
   ╎  1   @Base/special/exp.jl:216; exp_impl
   ╎   1   @Base/special/exp.jl:78; expm1b_kernel
   ╎    1   @Base/math.jl:186; evalpoly
   ╎     1   @Base/math.jl:187; macro expansion
  1╎    ╎ 1   @Base/float.jl:414; muladd
   ╎  1   @Base/special/exp.jl:218; exp_impl
  1╎   1   @Base/float.jl:610; abs
   ╎  1   @Base/special/exp.jl:229; exp_impl
  1╎   1   @Base/essentials.jl:581; reinterpret
Total snapshots: 882. Utilization: 100% across all threads and tasks. Use the `groupby` kwarg to break down by thread and/or task.
```

## Checklist

Requirements for merging:
- [ ] I have opened an issue or PR upstream on JuliaLang/julia: <link to JuliaLang/julia>
- [ ] I have removed the `port-to-*` labels that don't apply.
- [ ] I have opened a PR on raicode to test these changes: <link to raicode>
