### PR TITLE
Backport: add `--trace-compile-timing` arg to add compile timing comments (#54662)

### DIFF
--- a/base/options.jl
+++ b/base/options.jl
@@ -58,6 +58,7 @@ struct JLOptions
     strip_ir::Int8
     permalloc_pkgimg::Int8
     heap_size_hint::UInt64
+    trace_compile_timing::Int8
     safe_crash_log_file::Ptr{UInt8}
 end
 

--- a/doc/man/julia.1
+++ b/doc/man/julia.1
@@ -267,6 +267,10 @@ Generate an incremental output file (rather than complete)
 Print precompile statements for methods compiled during execution or save to a path
 
 .TP
+--trace-compile-timing=
+If --trace-compile is enabled show how long each took to compile in ms
+
+.TP
 -image-codegen
 Force generate code in imaging mode
 

--- a/doc/src/manual/command-line-interface.md
+++ b/doc/src/manual/command-line-interface.md
@@ -140,7 +140,8 @@ The following is a complete list of command-line switches available when launchi
 |`--output-bc <name>`                   |Generate LLVM bitcode (.bc)|
 |`--output-asm <name>`                  |Generate an assembly file (.s)|
 |`--output-incremental={yes\|no*}`      |Generate an incremental output file (rather than complete)|
-|`--trace-compile={stderr,name}`        |Print precompile statements for methods compiled during execution or save to a path|
+|`--trace-compile={stderr\|name}`       |Print precompile statements for methods compiled during execution or save to a path|
+|`--trace-compile-timing`               |If --trace-compile is enabled show how long each took to compile in ms|
 |`--image-codegen`                      |Force generate code in imaging mode|
 |`--heap-size-hint=<size>`              |Forces garbage collection if memory usage is higher than that value. The memory hint might be specified in megabytes (e.g., 500M) or gigabytes (e.g., 1G)|
 

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -91,6 +91,7 @@ JL_DLLEXPORT void jl_init_options(void)
                         0, // strip-ir
                         0, // permalloc_pkgimg
                         0, // heap-size-hint
+                        0, // trace_compile_timing
                         NULL, // safe_crash_log_file
     };
     jl_options_initialized = 1;
@@ -213,6 +214,7 @@ static const char opts_hidden[]  =
     "                          Generate an incremental output file (rather than complete)\n"
     " --trace-compile={stderr,name}\n"
     "                          Print precompile statements for methods compiled during execution or save to a path\n"
+    " --trace-compile-timing   If --trace-compile is enabled show how long each took to compile in ms\n"
     " --image-codegen          Force generate code in imaging mode\n"
     " --permalloc-pkgimg={yes|no*} Copy the data section of package images into memory\n"
 ;
@@ -235,6 +237,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
            opt_inline,
            opt_polly,
            opt_trace_compile,
+           opt_trace_compile_timing,
            opt_trace_dispatch,
            opt_math_mode,
            opt_worker,
@@ -741,7 +744,7 @@ restart_switch:
                 jl_errorf("julia: invalid argument to --inline (%s)", optarg);
             }
             break;
-       case opt_polly:
+        case opt_polly:
             if (!strcmp(optarg,"yes"))
                 jl_options.polly = JL_OPTIONS_POLLY_ON;
             else if (!strcmp(optarg,"no"))
@@ -750,12 +753,15 @@ restart_switch:
                 jl_errorf("julia: invalid argument to --polly (%s)", optarg);
             }
             break;
-         case opt_trace_compile:
+        case opt_trace_compile:
             jl_options.trace_compile = strdup(optarg);
             if (!jl_options.trace_compile)
                 jl_errorf("fatal error: failed to allocate memory: %s", strerror(errno));
             break;
-         case opt_trace_dispatch:
+        case opt_trace_compile_timing:
+            jl_options.trace_compile_timing = 1;
+            break;
+        case opt_trace_dispatch:
             jl_options.trace_dispatch = strdup(optarg);
             if (!jl_options.trace_dispatch)
                 jl_errorf("fatal error: failed to allocate memory: %s", strerror(errno));

--- a/src/jloptions.h
+++ b/src/jloptions.h
@@ -62,6 +62,7 @@ typedef struct {
     int8_t strip_ir;
     int8_t permalloc_pkgimg;
     uint64_t heap_size_hint;
+    int8_t trace_compile_timing;
     const char *safe_crash_log_file;
 } jl_options_t;
 

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -761,6 +761,17 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
         @test occursin("precompile(Tuple{typeof(Main.foo), Int", _stderr)
     end
 
+    # --trace-compile-timing
+    let
+        io = IOBuffer()
+        v = writereadpipeline(
+            "foo(x) = begin Base.Experimental.@force_compile; x; end; foo(1)",
+            `$exename --trace-compile=stderr --trace-compile-timing -i`,
+            stderr=io)
+        _stderr = String(take!(io))
+        @test occursin(" ms =# precompile(Tuple{typeof(Main.foo), Int", _stderr)
+    end
+
     # --trace-dispatch
     let
         io = IOBuffer()


### PR DESCRIPTION
<!---
PRs to RelationalAI/julia must be opened to the correct branch (see
https://github.com/RelationalAI/raicode/blob/master/nix/julia-version.json).
-->
## PR Description

```
% ./julia --trace-compile=stderr --trace-compile-timing --start=no -e "using ProfileView"
#=   0.0 ms =# precompile(Tuple{typeof(Requires.__init__)})
#=  19.4 ms =# precompile(Tuple{typeof(Requires.isprecompiling)})
#=   0.0 ms =# precompile(Tuple{typeof(Requires.listenpkg), Any, Base.PkgId})
#=   0.0 ms =# precompile(Tuple{typeof(Requires.loaded), Base.PkgId})
#=  13.4 ms =# precompile(Tuple{typeof(Base.haskey), Base.Dict{Base.PkgId, Module}, Base.PkgId})
#=   0.0 ms =# precompile(Tuple{typeof(Requires.callbacks), Base.PkgId})
#=   0.0 ms =# precompile(Tuple{typeof(Libiconv_jll.__init__)})
#=   0.0 ms =# precompile(Tuple{typeof(Libiconv_jll.find_artifact_dir)})
#=  32.0 ms =# precompile(Tuple{typeof(Artifacts._artifact_str), Module, String, Base.SubString{String}, String, Base.Dict{String, Any}, Base.SHA1, Base.BinaryPlatforms.Platform, Any})
#=   1.5 ms =# precompile(Tuple{typeof(Base.invokelatest), Any})
```

## Checklist

Requirements for merging:
- [X] I have opened an issue or PR upstream on JuliaLang/julia: https://github.com/JuliaLang/julia/pull/54662
- [X] I have removed the `port-to-*` labels that don't apply.
- [X] I have opened a PR on raicode to test these changes: https://github.com/RelationalAI/raicode/pull/21153
