### PR TITLE
expose metric to report reasons why full GCs were triggered (#55826)

### DIFF
--- a/src/gc.h
+++ b/src/gc.h
@@ -560,6 +560,21 @@ FORCE_INLINE void gc_big_object_link(bigval_t *sentinel_node, bigval_t *node) JL
     sentinel_node->next = node;
 }
 
+// Must be kept in sync with `base/timing.jl`
+#define FULL_SWEEP_REASON_SWEEP_ALWAYS_FULL (0)
+#define FULL_SWEEP_REASON_FORCED_FULL_SWEEP (1)
+#define FULL_SWEEP_REASON_ALLOCATION_INTERVAL_ABOVE_MAXMEM (2)
+#define FULL_SWEEP_REASON_LIVE_BYTES_ABOVE_MAX_TOTAL_MEMORY (3)
+#define FULL_SWEEP_REASON_LARGE_INTERGEN_FRONTIER (4)
+#define FULL_SWEEP_NUM_REASONS (5)
+
+extern JL_DLLEXPORT uint64_t jl_full_sweep_reasons[FULL_SWEEP_NUM_REASONS];
+STATIC_INLINE void gc_count_full_sweep_reason(int reason) JL_NOTSAFEPOINT
+{
+    assert(reason >= 0 && reason < FULL_SWEEP_NUM_REASONS);
+    jl_full_sweep_reasons[reason]++;
+}
+
 extern uv_mutex_t gc_threads_lock;
 extern uv_cond_t gc_threads_cond;
 extern uv_sem_t gc_sweep_assists_needed;

--- a/src/threading.c
+++ b/src/threading.c
@@ -1035,7 +1035,7 @@ JL_DLLEXPORT int jl_heartbeat_resume(void)
     if (uv_sem_trywait(&heartbeat_off_sem) != 0) {
         return -1;
     }
-    
+
     // reset state as we've been paused
     n_hbs_missed = 0;
     n_hbs_recvd = 0;

--- a/test/gc.jl
+++ b/test/gc.jl
@@ -28,6 +28,13 @@ function run_pg_size_test()
     @test page_size == (1 << 12) || page_size == (1 << 14)
 end
 
+function full_sweep_reasons_test()
+    GC.gc()
+    reasons = Base.full_sweep_reasons()
+    @test reasons[:FULL_SWEEP_REASON_FORCED_FULL_SWEEP] >= 1
+    @test keys(reasons) == Set(Base.FULL_SWEEP_REASONS)
+end
+
 # !!! note:
 #     Since we run our tests on 32bit OS as well we confine ourselves
 #     to parameters that allocate about 512MB of objects. Max RSS is lower
@@ -42,4 +49,8 @@ end
 @testset "GC page metrics" begin
     run_nonzero_page_utilization_test()
     run_pg_size_test()
+end
+
+@testset "Full GC reasons" begin
+    full_sweep_reasons_test()
 end


### PR DESCRIPTION
## PR Description

Backports https://github.com/JuliaLang/julia/pull/55826.

## Checklist

Requirements for merging:
- [x] I have opened an issue or PR upstream on JuliaLang/julia: https://github.com/JuliaLang/julia/pull/55826.
- [x] I have removed the `port-to-*` labels that don't apply.
- [x] I have opened a PR on raicode to test these changes: https://github.com/RelationalAI/raicode/pull/21227.
