### PR TITLE
Implement PaddedSpinlock

### DIFF
--- a/base/locks-mt.jl
+++ b/base/locks-mt.jl
@@ -52,7 +52,12 @@ PaddedSpinLocks are padded so that each is guaranteed to be on its own cache lin
 false sharing.
 """
 mutable struct PaddedSpinLock <: AbstractSpinLock
-    # we make this much larger than necessary to minimize false-sharing
+    # We make this much larger than necessary to minimize false-sharing.
+
+    # Strictly speaking, this is a little bit larger than it needs to be.  For a 64-byte
+    # cache line, this results in the size being 120 bytes.  Because these objects are
+    # 16-byte aligned, it would be enough if `PaddedSpinLock` was 112 bytes (with 48 bytes
+    # in the before padding and 56 bytes in the after padding).
     _padding_before::NTuple{max(0, CACHE_LINE_SIZE - sizeof(Int)), UInt8}
     @atomic owned::Int
     _padding_after::NTuple{max(0, CACHE_LINE_SIZE - sizeof(Int)), UInt8}

--- a/base/locks-mt.jl
+++ b/base/locks-mt.jl
@@ -2,7 +2,7 @@
 
 import .Base: unsafe_convert, lock, trylock, unlock, islocked, wait, notify, AbstractLock
 
-export SpinLock
+export AbstractSpinLock, PaddedSpinLock, SpinLock
 
 # Important Note: these low-level primitives defined here
 #   are typically not for general usage
@@ -21,9 +21,8 @@ to execute and does not block (e.g. perform I/O).
 In general, [`ReentrantLock`](@ref) should be used instead.
 
 Each [`lock`](@ref) must be matched with an [`unlock`](@ref).
-If [`!islocked(lck::AbstractSpinLock)`](@ref islocked) holds, 
-[`trylock(lck)`](@ref trylock) succeeds unless there are other tasks attempting to hold the
-lock "at the same time."
+If [`!islocked(lck::AbstractSpinLock)`](@ref islocked) holds, [`trylock(lck)`](@ref trylock)
+succeeds unless there are other tasks attempting to hold the lock "at the same time."
 
 Test-and-test-and-set spin locks are quickest up to about 30ish
 contending threads. If you have more contention than that, different

--- a/doc/src/base/multi-threading.md
+++ b/doc/src/base/multi-threading.md
@@ -69,5 +69,13 @@ Base.@threadcall
 These building blocks are used to create the regular synchronization objects.
 
 ```@docs
+Base.Threads.AbstractSpinLock
+```
+
+```@docs
 Base.Threads.SpinLock
+```
+
+```@docs
+Base.Threads.PaddedSpinLock
 ```

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -53,24 +53,25 @@ if threadpoolsize() > 1
     end
 end
 
-# basic padded spin lock check
-if threadpoolsize() > 1
-    let lk = PaddedSpinLock()
-        c1 = Base.Event()
-        c2 = Base.Event()
-        @test trylock(lk)
-        @test !trylock(lk)
-        t1 = Threads.@spawn (notify(c1); lock(lk); unlock(lk); trylock(lk))
-        t2 = Threads.@spawn (notify(c2); trylock(lk))
-        Libc.systemsleep(0.1) # block our thread from scheduling for a bit
-        wait(c1)
-        wait(c2)
-        @test !fetch(t2)
-        @test istaskdone(t2)
-        @test !istaskdone(t1)
-        unlock(lk)
-        @test fetch(t1)
-        @test istaskdone(t1)
+@testset "basic padded spin lock check"
+    if threadpoolsize() > 1
+        let lk = PaddedSpinLock()
+            c1 = Base.Event()
+            c2 = Base.Event()
+            @test trylock(lk)
+            @test !trylock(lk)
+            t1 = Threads.@spawn (notify(c1); lock(lk); unlock(lk); trylock(lk))
+            t2 = Threads.@spawn (notify(c2); trylock(lk))
+            Libc.systemsleep(0.1) # block our thread from scheduling for a bit
+            wait(c1)
+            wait(c2)
+            @test !fetch(t2)
+            @test istaskdone(t2)
+            @test !istaskdone(t1)
+            unlock(lk)
+            @test fetch(t1)
+            @test istaskdone(t1)
+        end
     end
 end
 

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -53,6 +53,28 @@ if threadpoolsize() > 1
     end
 end
 
+# basic padded spin lock check
+if threadpoolsize() > 1
+    let lk = PaddedSpinLock()
+        c1 = Base.Event()
+        c2 = Base.Event()
+        @test trylock(lk)
+        @test !trylock(lk)
+        t1 = Threads.@spawn (notify(c1); lock(lk); unlock(lk); trylock(lk))
+        t2 = Threads.@spawn (notify(c2); trylock(lk))
+        Libc.systemsleep(0.1) # block our thread from scheduling for a bit
+        wait(c1)
+        wait(c2)
+        @test !fetch(t2)
+        @test istaskdone(t2)
+        @test !istaskdone(t1)
+        unlock(lk)
+        @test fetch(t1)
+        @test istaskdone(t1)
+    end
+end
+
+
 # threading constructs
 
 let a = zeros(Int, 2 * threadpoolsize())


### PR DESCRIPTION
<!---
PRs to RelationalAI/julia must be opened to the correct branch (see
https://github.com/RelationalAI/raicode/blob/master/nix/julia-version.json).
-->
## PR Description

Create `PaddedSpinLock` that avoids false sharing.  We have a new `AbstractSpinLock` with `SpinLock <: AbstractSpinLock` and `PaddedSpinLock <: AbstractSpinLock`.

## Checklist

Requirements for merging:
- [x] I have opened an issue or PR upstream on JuliaLang/julia: [SpinLocks suffer from false sharing](https://github.com/JuliaLang/julia/issues/55942)
- [ ] I have removed the `port-to-*` labels that don't apply.
- [ ] I have opened a PR on raicode to test these changes: <link to raicode>
