### PR TITLE
Only update the world age when a new method is loaded

### DIFF
--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -840,6 +840,10 @@ static jl_array_t *jl_verify_edges(jl_array_t *targets, size_t minworld)
     if (ulong_array == NULL)
         ulong_array = jl_apply_array_type((jl_value_t*)jl_ulong_type, 1);
     jl_array_t *maxvalids = jl_alloc_array_1d(ulong_array, l);
+    if (minworld == jl_base_module->primary_world) {
+        memset(jl_array_data(maxvalids), -1, l * sizeof(size_t));
+        return maxvalids;
+    }
     memset(jl_array_data(maxvalids), 0, l * sizeof(size_t));
     jl_value_t *loctag = NULL;
     jl_value_t *matches = NULL;


### PR DESCRIPTION
<!---
PRs to RelationalAI/julia must be opened to the correct branch (see
https://github.com/RelationalAI/raicode/blob/master/nix/julia-version.json).
-->
## PR Description

Instead of always updating it. This should speed up loading only method specializations.

## Checklist

Requirements for merging:
- [ ] I have opened an issue or PR upstream on JuliaLang/julia: <link to JuliaLang/julia>
- [X] I have removed the `port-to-*` labels that don't apply.
- [X] I have opened a PR on raicode to test these changes: https://github.com/RelationalAI/raicode/pull/21857
