### PR TITLE
Fix trampoline assembly for build on clang 18 on apple silicon (#54634)

### DIFF
--- a/cli/trampolines/trampolines_aarch64.S
+++ b/cli/trampolines/trampolines_aarch64.S
@@ -5,9 +5,9 @@
 
 #define XX(name) \
 .global CNAME(name) SEP \
+CNAME(name)##: SEP \
 .cfi_startproc SEP \
 .p2align    2 SEP \
-CNAME(name)##: SEP \
     adrp x16, PAGE(CNAME(name##_addr)) SEP \
     ldr x16, [x16, PAGEOFF(CNAME(name##_addr))] SEP \
     br x16 SEP \


### PR DESCRIPTION
This avoids a: `error: non-private labels cannot appear between .cfi_startproc / .cfi_endproc pairs` error.
That error was introduced in https://reviews.llvm.org/D155245#4657075 see also https://github.com/llvm/llvm-project/issues/72802

(cherry picked from commit a4e793ee31612625d9c48ebd89a53c3a5c0f6eb6) (cherry picked from commit 3f35094d298b41d57f3f3a8c5a9abd52bcf47b30)

<!---
PRs to RelationalAI/julia must be opened to the correct branch (see
https://github.com/RelationalAI/raicode/blob/master/nix/julia-version.json).
-->
## PR Description

_What does this PR do?_

## Checklist

Requirements for merging:
- [x] I have opened an issue or PR upstream on JuliaLang/julia: https://github.com/JuliaLang/julia/pull/54634
- [x] I have removed the `port-to-*` labels that don't apply.
- [x] I have opened a PR on raicode to test these changes: https://github.com/RelationalAI/raicode/pull/22029
