### PR TITLE
skip heartbeat thread from CPU profile

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -220,6 +220,7 @@ extern volatile size_t profile_bt_size_max;
 extern volatile size_t profile_bt_size_cur;
 extern volatile int profile_running;
 extern volatile int profile_all_tasks;
+extern int heartbeat_tid; // Mostly used to ensure we skip this thread in the CPU profiler. XXX: not implemented on Windows
 // Ensures that we can safely read the `live_tasks`field of every TLS when profiling.
 // We want to avoid the case that a GC gets interleaved with `jl_profile_task` and shrinks
 // the `live_tasks` array while we are reading it or frees tasks that are being profiled.

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -708,6 +708,10 @@ void *mach_profile_listener(void *arg)
             for (int idx = nthreads; idx-- > 0; ) {
                 // Stop the threads in random order.
                 int i = randperm[idx];
+                // skip heartbeat thread
+                if (i == heartbeat_tid) {
+                    continue;
+                }
                 jl_profile_thread_mach(i);
             }
         }

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -933,6 +933,10 @@ static void *signal_listener(void *arg)
                 for (int idx = nthreads; idx-- > 0; ) {
                     // Stop the threads in the random order.
                     int i = randperm[idx];
+                    // skip heartbeat thread
+                    if (i == heartbeat_tid) {
+                        continue;
+                    }
                     // do backtrace for profiler
                     if (profile_running) {
                         jl_profile_thread_unix(i, &signal_context);

--- a/src/threading.c
+++ b/src/threading.c
@@ -943,6 +943,7 @@ JL_DLLEXPORT int jl_alignment(size_t sz)
 #include <time.h>
 
 volatile int heartbeat_enabled;
+int heartbeat_tid; // Mostly used to ensure we skip this thread in the CPU profiler. XXX: not implemented on Windows
 uv_thread_t heartbeat_uvtid;
 uv_sem_t heartbeat_on_sem,              // jl_heartbeat_enable -> thread
          heartbeat_off_sem;             // thread -> jl_heartbeat_enable
@@ -1130,6 +1131,7 @@ void jl_heartbeat_threadfun(void *arg)
     jl_adopt_thread();
     jl_task_t *ct = jl_current_task;
     jl_ptls_t ptls = ct->ptls;
+    heartbeat_tid = ptls->tid;
 
     // Don't hold up GC, this thread doesn't participate.
     uint8_t gc_state = jl_gc_safe_enter(ptls);


### PR DESCRIPTION
## PR Description

Intentionally skips the heartbeat thread from the CPU profiler, so that we don't include a large number of useless samples from `semaphore_wait_trap`.

X-ref: https://relationalai.atlassian.net/browse/RAI-31811.

## Checklist

Requirements for merging:
- [X] I have opened an issue or PR upstream on JuliaLang/julia: N/A.
- [x] I have removed the `port-to-*` labels that don't apply.
- [x] I have opened a PR on raicode to test these changes: https://github.com/RelationalAI/raicode/pull/22572.
