### PR TITLE
Add `@min_optlevel` to set a min-optlevel for a module

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -96,6 +96,7 @@ JL_DLLEXPORT jl_sym_t *jl_escape_sym;
 JL_DLLEXPORT jl_sym_t *jl_aliasscope_sym;
 JL_DLLEXPORT jl_sym_t *jl_popaliasscope_sym;
 JL_DLLEXPORT jl_sym_t *jl_optlevel_sym;
+JL_DLLEXPORT jl_sym_t *jl_min_optlevel_sym;
 JL_DLLEXPORT jl_sym_t *jl_thismodule_sym;
 JL_DLLEXPORT jl_sym_t *jl_atom_sym;
 JL_DLLEXPORT jl_sym_t *jl_statement_sym;
@@ -345,6 +346,7 @@ void jl_init_common_symbols(void)
     jl_specialize_sym = jl_symbol("specialize");
     jl_nospecializeinfer_sym = jl_symbol("nospecializeinfer");
     jl_optlevel_sym = jl_symbol("optlevel");
+    jl_min_optlevel_sym = jl_symbol("min_optlevel");
     jl_compile_sym = jl_symbol("compile");
     jl_force_compile_sym = jl_symbol("force_compile");
     jl_infer_sym = jl_symbol("infer");

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7416,6 +7416,11 @@ static jl_llvm_functions_t
         static const char* const optLevelStrings[] = { "0", "1", "2", "3" };
         FnAttrs.addAttribute("julia-optimization-level", optLevelStrings[optlevel]);
     }
+    int min_optlevel = jl_get_module_min_optlevel(ctx.module);
+    if (min_optlevel >= 0 && min_optlevel <= 3) {
+        static const char* const optLevelStrings[] = { "0", "1", "2", "3" };
+        FnAttrs.addAttribute("julia-min-optimization-level", optLevelStrings[min_optlevel]);
+    }
 
     ctx.f = f;
 

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -596,6 +596,12 @@ static jl_value_t *eval_body(jl_array_t *stmts, interpreter_state *s, size_t ip,
                                 jl_set_module_optlevel(s->module, n);
                             }
                         }
+                        else if (jl_exprarg(stmt, 0) == (jl_value_t*)jl_min_optlevel_sym) {
+                            if (jl_is_long(jl_exprarg(stmt, 1))) {
+                                int n = jl_unbox_long(jl_exprarg(stmt, 1));
+                                jl_set_module_min_optlevel(s->module, n);
+                            }
+                        }
                         else if (jl_exprarg(stmt, 0) == (jl_value_t*)jl_compile_sym) {
                             if (jl_is_long(jl_exprarg(stmt, 1))) {
                                 jl_set_module_compile(s->module, jl_unbox_long(jl_exprarg(stmt, 1)));

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -708,6 +708,14 @@ void JuliaOJIT::OptSelLayerT::emit(std::unique_ptr<orc::MaterializationResponsib
                         if (ol < optlevel)
                             optlevel = ol;
                     }
+                    attr = F.getFnAttribute("julia-min-optimization-level");
+                    val = attr.getValueAsString();
+                    if (val != "") {
+                        size_t ol = (size_t)val[0] - '0';
+                        if (ol > opt_level)
+                            opt_level = ol;
+                        jl_safe_printf("Function %s opt: %d\n", F.getName().str().c_str(), (int)opt_level);
+                    }
                 }
             }
             optlevel = std::min(std::max(optlevel, optlevel_min), this->count);

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -227,6 +227,7 @@
     XX(jl_get_module_infer) \
     XX(jl_get_module_of_binding) \
     XX(jl_get_module_optlevel) \
+    XX(jl_get_module_min_optlevel) \
     XX(jl_get_next_task) \
     XX(jl_get_nth_field) \
     XX(jl_get_nth_field_checked) \
@@ -420,6 +421,7 @@
     XX(jl_set_module_infer) \
     XX(jl_set_module_nospecialize) \
     XX(jl_set_module_optlevel) \
+    XX(jl_set_module_min_optlevel) \
     XX(jl_set_module_uuid) \
     XX(jl_set_next_task) \
     XX(jl_set_nth_field) \

--- a/src/julia.h
+++ b/src/julia.h
@@ -630,6 +630,7 @@ typedef struct _jl_module_t {
     _Atomic(uint32_t) counter;
     int32_t nospecialize;  // global bit flags: initialization for new methods
     int8_t optlevel;
+    int8_t min_optlevel;
     int8_t compile;
     int8_t infer;
     uint8_t istopmod;
@@ -1725,7 +1726,9 @@ extern JL_DLLIMPORT jl_module_t *jl_top_module JL_GLOBALLY_ROOTED;
 JL_DLLEXPORT jl_module_t *jl_new_module(jl_sym_t *name, jl_module_t *parent);
 JL_DLLEXPORT void jl_set_module_nospecialize(jl_module_t *self, int on);
 JL_DLLEXPORT void jl_set_module_optlevel(jl_module_t *self, int lvl);
+JL_DLLEXPORT void jl_set_module_min_optlevel(jl_module_t *self, int lvl);
 JL_DLLEXPORT int jl_get_module_optlevel(jl_module_t *m);
+JL_DLLEXPORT int jl_get_module_min_optlevel(jl_module_t *m);
 JL_DLLEXPORT void jl_set_module_compile(jl_module_t *self, int value);
 JL_DLLEXPORT int jl_get_module_compile(jl_module_t *m);
 JL_DLLEXPORT void jl_set_module_infer(jl_module_t *self, int value);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1668,6 +1668,7 @@ extern JL_DLLEXPORT jl_sym_t *jl_escape_sym;
 extern JL_DLLEXPORT jl_sym_t *jl_aliasscope_sym;
 extern JL_DLLEXPORT jl_sym_t *jl_popaliasscope_sym;
 extern JL_DLLEXPORT jl_sym_t *jl_optlevel_sym;
+extern JL_DLLEXPORT jl_sym_t *jl_min_optlevel_sym;
 extern JL_DLLEXPORT jl_sym_t *jl_thismodule_sym;
 extern JL_DLLEXPORT jl_sym_t *jl_atom_sym;
 extern JL_DLLEXPORT jl_sym_t *jl_statement_sym;

--- a/src/module.c
+++ b/src/module.c
@@ -32,6 +32,7 @@ JL_DLLEXPORT jl_module_t *jl_new_module_(jl_sym_t *name, jl_module_t *parent, ui
     jl_atomic_store_relaxed(&m->counter, 1);
     m->nospecialize = 0;
     m->optlevel = -1;
+    m->min_optlevel = -1;
     m->compile = -1;
     m->infer = -1;
     m->max_methods = -1;
@@ -86,6 +87,10 @@ JL_DLLEXPORT void jl_set_module_optlevel(jl_module_t *self, int lvl)
 {
     self->optlevel = lvl;
 }
+JL_DLLEXPORT void jl_set_module_min_optlevel(jl_module_t *self, int lvl)
+{
+    self->min_optlevel = lvl;
+}
 
 JL_DLLEXPORT int jl_get_module_optlevel(jl_module_t *m)
 {
@@ -96,6 +101,16 @@ JL_DLLEXPORT int jl_get_module_optlevel(jl_module_t *m)
     }
     return lvl;
 }
+JL_DLLEXPORT int jl_get_module_min_optlevel(jl_module_t *m)
+{
+    int lvl = m->min_optlevel;
+    while (lvl == -1 && m->parent != m && m != jl_base_module) {
+        m = m->parent;
+        lvl = m->min_optlevel;
+    }
+    return lvl;
+}
+
 
 JL_DLLEXPORT void jl_set_module_compile(jl_module_t *self, int value)
 {


### PR DESCRIPTION
## PR Description

Add `@min_optlevel 2` to specify a lower-bound of optimization-level for a module.

## Checklist

Requirements for merging:
- [ ] I have opened an issue or PR upstream on JuliaLang/julia: <link to JuliaLang/julia>
- [x] I have removed the `port-to-*` labels that don't apply.
- [ ] I have opened a PR on raicode to test these changes: <link to raicode>
