### PR TITLE
Add try/catch around handle_message() to catch errors during logging (#57004)

### DIFF
--- a/base/logging.jl
+++ b/base/logging.jl
@@ -398,7 +398,7 @@ function logmsg_code(_module, file, line, level, message, exs...)
                         end
                         line = $(log_data._line)
                         local msg, kwargs
-                        $(logrecord) && invokelatest($handle_message,
+                        $(logrecord) && $handle_message_nothrow(
                             logger, level, msg, _module, group, id, file, line;
                             kwargs...)
                     end
@@ -406,6 +406,18 @@ function logmsg_code(_module, file, line, level, message, exs...)
             end
             nothing
         end
+    end
+end
+
+@noinline function handle_message_nothrow(logger, level, msg, _module, group, id, file, line; kwargs...)
+    @nospecialize
+    try
+        @invokelatest handle_message(
+            logger, level, msg, _module, group, id, file, line;
+            kwargs...)
+
+    catch err
+        @invokelatest logging_error(logger, level, _module, group, id, file, line, err, true)
     end
 end
 

--- a/test/corelogging.jl
+++ b/test/corelogging.jl
@@ -114,6 +114,19 @@ end
         @test only(collect_test_logs(logmsg)[1]).kwargs[:x] === "the y"
     end
 end
+@testset "Log message handle_message exception handling" begin
+    # Exceptions in log handling (printing) of msg are caught by default.
+    struct Foo end
+    Base.show(::IO, ::Foo) = 1 ÷ 0
+
+    # We cannot use `@test_logs` here, since test_logs does not actually _print_ the message
+    # (i.e. it does not invoke handle_message). To test exception handling during printing,
+    # we have to use `@test_warn` to see what was printed.
+    @test_warn r"Error: Exception while generating log record in module .*DivideError: integer division error"s @info Foo()
+
+    # Exceptions in log handling (printing) of attributes are caught by default
+    @test_warn r"Error: Exception while generating log record in module .*DivideError: integer division error"s @info "foo" x=Foo()
+end
 
 @testset "Special keywords" begin
     logger = TestLogger()


### PR DESCRIPTION
## PR Description

Backport fix to prevent failed transactions from logging bugs.
Fixes [RAI-33715](https://relationalai.atlassian.net/browse/RAI-33715).

## Checklist

Requirements for merging:
- [x] I have opened an issue or PR upstream on JuliaLang/julia: https://github.com/JuliaLang/julia/pull/57004
- [x] I have removed the `port-to-*` labels that don't apply.
- [x] I have opened a PR on raicode to test these changes: https://github.com/RelationalAI/raicode/pull/22794

[RAI-33715]: https://relationalai.atlassian.net/browse/RAI-33715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ