### PR TITLE
add option to dump backtrace of stop-the-world straggler (#57045)

### DIFF
--- a/base/options.jl
+++ b/base/options.jl
@@ -61,6 +61,7 @@ struct JLOptions
     trace_compile_timing::Int8
     safe_crash_log_file::Ptr{UInt8}
     task_metrics::Int8
+    timeout_for_safepoint_straggler_s::Int16
 end
 
 # This runs early in the sysimage != is not defined yet

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -94,6 +94,7 @@ JL_DLLEXPORT void jl_init_options(void)
                         0, // trace_compile_timing
                         NULL, // safe_crash_log_file
                         0, // task_metrics
+                        -1, // timeout_for_safepoint_straggler_s
     };
     jl_options_initialized = 1;
 }
@@ -214,6 +215,8 @@ static const char opts_hidden[]  =
     " --output-asm <name>                           Generate an assembly file (.s)\n"
     " --output-incremental={yes|no*}                Generate an incremental output file (rather than\n"
     "                                               complete)\n"
+    " --timeout-for-safepoint-straggler <seconds>   If this value is set, then we will dump the backtrace for a thread\n"
+    "                                               that fails to reach a safepoint within the specified time\n"
     " --trace-compile={stderr|name}                 Print precompile statements for methods compiled\n"
     "                                               during execution or save to stderr or a path. Methods that\n"
     "                                               were recompiled are printed in yellow or with a trailing\n"
@@ -242,6 +245,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
            opt_warn_scope,
            opt_inline,
            opt_polly,
+           opt_timeout_for_safepoint_straggler,
            opt_trace_compile,
            opt_trace_compile_timing,
            opt_trace_dispatch,
@@ -321,6 +325,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
         { "warn-scope",      required_argument, 0, opt_warn_scope },
         { "inline",          required_argument, 0, opt_inline },
         { "polly",           required_argument, 0, opt_polly },
+        { "timeout-for-safepoint-straggler", required_argument, 0, opt_timeout_for_safepoint_straggler },
         { "trace-compile",   required_argument, 0, opt_trace_compile },
         { "trace-compile-timing",  no_argument, 0, opt_trace_compile_timing },
         { "trace-dispatch",  required_argument, 0, opt_trace_dispatch },
@@ -880,6 +885,13 @@ restart_switch:
             jl_options.safe_crash_log_file = strdup(optarg);
             if (jl_options.safe_crash_log_file == NULL)
                 jl_error("julia: failed to allocate memory for --safe-crash-log-file");
+            break;
+        case opt_timeout_for_safepoint_straggler:
+            errno = 0;
+            long timeout = strtol(optarg, &endptr, 10);
+            if (errno != 0 || optarg == endptr || timeout < 1 || timeout > INT16_MAX)
+                jl_errorf("julia: --timeout-for-safepoint-straggler=<seconds>; seconds must be an integer between 1 and %d", INT16_MAX);
+            jl_options.timeout_for_safepoint_straggler_s = (int16_t)timeout;
             break;
         case opt_task_metrics:
             if (!strcmp(optarg, "no"))

--- a/src/jloptions.h
+++ b/src/jloptions.h
@@ -65,6 +65,7 @@ typedef struct {
     int8_t trace_compile_timing;
     const char *safe_crash_log_file;
     int8_t task_metrics;
+    int16_t timeout_for_safepoint_straggler_s;
 } jl_options_t;
 
 #endif

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -213,6 +213,8 @@ typedef struct {
     size_t bt_size;
     int tid;
 } jl_record_backtrace_result_t;
+JL_DLLEXPORT JL_DLLEXPORT size_t jl_try_record_thread_backtrace(jl_ptls_t ptls2, struct _jl_bt_element_t *bt_data,
+                                                                size_t max_bt_size) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_record_backtrace_result_t jl_record_backtrace(jl_task_t *t, struct _jl_bt_element_t *bt_data,
                                                               size_t max_bt_size, int all_tasks_profiler) JL_NOTSAFEPOINT;
 extern volatile struct _jl_bt_element_t *profile_bt_data_prof;

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -1126,3 +1126,9 @@ end
 #heap-size-hint, we reserve 250 MB for non GC memory (llvm, etc.)
 @test readchomp(`$(Base.julia_cmd()) --startup-file=no --heap-size-hint=500M -e "println(@ccall jl_gc_get_max_memory()::UInt64)"`) == "$((500-250)*1024*1024)"
 end
+
+@testset "--timeout-for-safepoint-straggler" begin
+    exename = `$(Base.julia_cmd())`
+    timeout = 120
+    @test parse(Int,read(`$exename --timeout-for-safepoint-straggler=$timeout -E "Base.JLOptions().timeout_for_safepoint_straggler_s"`, String)) == timeout
+end

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -1313,4 +1313,29 @@ end
     end
 end
 
+@testset "--timeout-for-safepoint-straggler command-line flag" begin
+    program = "
+        function main()
+            t = Threads.@spawn begin
+                ccall(:uv_sleep, Cvoid, (Cuint,), 5000)
+            end
+            # Force a GC
+            ccall(:uv_sleep, Cvoid, (Cuint,), 1000)
+            GC.gc()
+            wait(t)
+        end
+        main()
+    "
+    tmp_output_filename = tempname()
+    tmp_output_file = open(tmp_output_filename, "w")
+    if isnothing(tmp_output_file)
+        error("Failed to open file $tmp_output_filename")
+    end
+    run(pipeline(`$(Base.julia_cmd()) --threads=4 --timeout-for-safepoint-straggler=1 -e $program`, stderr=tmp_output_file))
+    # Check whether we printed the straggler's backtrace
+    @test !isempty(read(tmp_output_filename, String))
+    close(tmp_output_file)
+    rm(tmp_output_filename)
+end
+
 end # main testset


### PR DESCRIPTION
## PR Description

Backports https://github.com/JuliaLang/julia/pull/57045.

I needed to make some minor adjustments in `jl_gc_wait_for_the_world`, because we're spinning waiting for the safepoint in 1.10, but we sleep on a condition in 1.12.

Marking as draft until I make the adjustments (e.g. pretty-printing the backtraces to JSON) to make sure this shows up on DD.

## Checklist

Requirements for merging:
- [x] I have opened an issue or PR upstream on JuliaLang/julia: https://github.com/JuliaLang/julia/pull/57045.
- [x] I have removed the `port-to-*` labels that don't apply.
- [ ] I have opened a PR on raicode to test these changes: <link to raicode>
