### PR TITLE
Add timing when `PRECOMPILE_TRACE_COMPILE` is set (#57251)

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2273,7 +2273,11 @@ function create_expr_cache(pkg::PkgId, input::String, output::String, output_o::
 
     deps_eltype = sprint(show, eltype(concrete_deps); context = :module=>nothing)
     deps = deps_eltype * "[" * join(deps_strs, ",") * "]"
-    trace = isassigned(PRECOMPILE_TRACE_COMPILE) ? `--trace-compile=$(PRECOMPILE_TRACE_COMPILE[])` : ``
+    trace = if isassigned(PRECOMPILE_TRACE_COMPILE)
+        `--trace-compile=$(PRECOMPILE_TRACE_COMPILE[]) --trace-compile-timing`
+    else
+        ``
+    end
     io = open(pipeline(addenv(`$(julia_cmd(;cpu_target)::Cmd) $(opts)
                               --startup-file=no --history-file=no --warn-overwrite=yes
                               --color=$(have_color === nothing ? "auto" : have_color ? "yes" : "no")


### PR DESCRIPTION
<!---
PRs to RelationalAI/julia must be opened to the correct branch (see
https://github.com/RelationalAI/raicode/blob/master/nix/julia-version.json).
-->
## PR Description

If we set `Base.PRECOMPILE_TRACE_COMPILE[] = <filename>`, Julia compilation will emit compilation traces with timing information.

## Checklist

Requirements for merging:
- [X] I have opened an issue or PR upstream on JuliaLang/julia: https://github.com/JuliaLang/julia/pull/57251
- [X] I have removed the `port-to-*` labels that don't apply.
- [X] I have opened a PR on raicode to test these changes: https://github.com/RelationalAI/raicode/pull/23049
