### PR TITLE
Make sure backtrace printed by STW straggler goes into safe-log-file

### DIFF
--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -754,6 +754,7 @@ STATIC_INLINE void write_to_safe_crash_log(char *buf) JL_NOTSAFEPOINT
 }
 
 extern int jl_inside_heartbeat_thread(void);
+extern int jl_inside_waiting_for_the_world(void);
 
 JL_DLLEXPORT void jl_safe_printf(const char *fmt, ...)
 {
@@ -774,7 +775,7 @@ JL_DLLEXPORT void jl_safe_printf(const char *fmt, ...)
     // order is important here: we want to ensure that the threading infra
     // has been initialized before we start trying to print to the
     // safe crash log file
-    if (jl_sig_fd != 0 && (jl_inside_signal_handler() || jl_inside_heartbeat_thread())) {
+    if (jl_sig_fd != 0 && (jl_inside_signal_handler() || jl_inside_heartbeat_thread() || jl_inside_waiting_for_the_world())) {
         write_to_safe_crash_log(buf);
     }
     if (write(STDERR_FILENO, buf, strlen(buf)) < 0) {


### PR DESCRIPTION
## PR Description

### MWE:

```Julia
function main()
    t = Threads.@spawn begin
        ccall(:uv_sleep, Cvoid, (Cuint,), 5000)
    end
    # Force a GC
    ccall(:uv_sleep, Cvoid, (Cuint,), 1000)
    GC.gc()
    wait(t)
end
main()
```

### Command:

```
julia -t4 --timeout-for-safepoint-straggler=1 --safe-crash-log-file=/tmp/foobar.txt mwe.jl
```

### Output:

Ran:

```
cat /tmp/foobar.txt 
```

And got:

```

{"level":"Error", "timestamp":"2025-02-04T18:27:20.513", "message": "===== Thread 2 failed to reach safepoint after 1 seconds, printing backtrace below =====\n"}

{"level":"Error", "timestamp":"2025-02-04T18:27:20.651", "message": "thread (1) __semwait_signal at /usr/lib/system/libsystem_kernel.dylib (unknown line)\n"}

{"level":"Error", "timestamp":"2025-02-04T18:27:21.651", "message": "===== Thread 2 failed to reach safepoint after 1 seconds, printing backtrace below =====\n"}

{"level":"Error", "timestamp":"2025-02-04T18:27:21.652", "message": "thread (1) __semwait_signal at /usr/lib/system/libsystem_kernel.dylib (unknown line)\n"}

{"level":"Error", "timestamp":"2025-02-04T18:27:22.652", "message": "===== Thread 2 failed to reach safepoint after 1 seconds, printing backtrace below =====\n"}

{"level":"Error", "timestamp":"2025-02-04T18:27:22.652", "message": "thread (1) __semwait_signal at /usr/lib/system/libsystem_kernel.dylib (unknown line)\n"}
```

## Checklist

Requirements for merging:
- [x] I have opened an issue or PR upstream on JuliaLang/julia: N/A.
- [x] I have removed the `port-to-*` labels that don't apply.
- [ ] I have opened a PR on raicode to test these changes: <link to raicode>
