### PR TITLE
Use `uv_thread_equal` to compare thread IDs

### DIFF
--- a/src/threading.c
+++ b/src/threading.c
@@ -969,7 +969,7 @@ void jl_init_heartbeat(void)
 int jl_inside_heartbeat_thread(void)
 {
     uv_thread_t curr_uvtid = uv_thread_self();
-    return curr_uvtid == heartbeat_uvtid;
+    return uv_thread_equal(&curr_uvtid, &heartbeat_uvtid);
 }
 
 // enable/disable heartbeats


### PR DESCRIPTION
<!---
PRs to RelationalAI/julia must be opened to the correct branch (see
https://github.com/RelationalAI/raicode/blob/master/nix/julia-version.json).
-->
## PR Description

And not `==`.

## Checklist

Requirements for merging:
- [ ] I have opened an issue or PR upstream on JuliaLang/julia: <link to JuliaLang/julia>
- [X] I have removed the `port-to-*` labels that don't apply.
- [ ] I have opened a PR on raicode to test these changes: <link to raicode>
