### PR TITLE
Use `Base.process_status(p)` instead of `p.exitcode` in error message…

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2477,7 +2477,7 @@ function compilecache(pkg::PkgId, path::String, internal_stderr::IO = stderr, in
     if p.exitcode == 125
         return PrecompilableError()
     else
-        error("Failed to precompile $(repr("text/plain", pkg)) to $(repr(tmppath)) (exit code $(p.exitcode)).")
+        error("Failed to precompile $(repr("text/plain", pkg)) to $(repr(tmppath)) ($(Base.process_status(p))).")
     end
 end
 


### PR DESCRIPTION
<!---
PRs to RelationalAI/julia must be opened to the correct branch (see
https://github.com/RelationalAI/raicode/blob/master/nix/julia-version.json).
-->
## PR Description

… (#57460)

Fixup https://github.com/JuliaLang/julia/pull/57455

## Checklist

Requirements for merging:
- [X] I have opened an issue or PR upstream on JuliaLang/julia: https://github.com/JuliaLang/julia/pull/57460
- [X] I have removed the `port-to-*` labels that don't apply.
- [ ] I have opened a PR on raicode to test these changes: <link to raicode>
