### PR TITLE
enable safepoint straggler bt printing unconditionally

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -254,7 +254,7 @@ void jl_gc_wait_for_the_world(jl_ptls_t* gc_all_tls_states, int gc_n_threads)
             // We're currently also using atomic store release in mutator threads
             // (in jl_gc_state_set), but we may want to use signals to flush the
             // memory operations on those threads lazily instead.
-            const int64_t timeout = jl_options.timeout_for_safepoint_straggler_s * 1000000000; // convert to nanoseconds
+            const int64_t timeout = jl_options.timeout_for_safepoint_straggler_s * 1000000000LL; // convert to nanoseconds
             uint64_t t0 = jl_hrtime();
             while (!jl_atomic_load_relaxed(&ptls2->gc_state) || !jl_atomic_load_acquire(&ptls2->gc_state)) {
                 jl_cpu_pause(); // yield?

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -94,7 +94,7 @@ JL_DLLEXPORT void jl_init_options(void)
                         0, // trace_compile_timing
                         NULL, // safe_crash_log_file
                         0, // task_metrics
-                        -1, // timeout_for_safepoint_straggler_s
+                        60, // timeout_for_safepoint_straggler_s
     };
     jl_options_initialized = 1;
 }

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -1317,25 +1317,27 @@ end
     program = "
         function main()
             t = Threads.@spawn begin
-                ccall(:uv_sleep, Cvoid, (Cuint,), 5000)
+                ccall(:uv_sleep, Cvoid, (Cuint,), 20_000)
             end
             # Force a GC
-            ccall(:uv_sleep, Cvoid, (Cuint,), 1000)
+            ccall(:uv_sleep, Cvoid, (Cuint,), 1_000)
             GC.gc()
             wait(t)
         end
         main()
     "
-    tmp_output_filename = tempname()
-    tmp_output_file = open(tmp_output_filename, "w")
-    if isnothing(tmp_output_file)
-        error("Failed to open file $tmp_output_filename")
+    for timeout in ("1", "4", "16")
+        tmp_output_filename = tempname()
+        tmp_output_file = open(tmp_output_filename, "w")
+        if isnothing(tmp_output_file)
+            error("Failed to open file $tmp_output_filename")
+        end
+        run(pipeline(`$(Base.julia_cmd()) --threads=4 --timeout-for-safepoint-straggler=$(timeout) -e $program`, stderr=tmp_output_file))
+        # Check whether we printed the straggler's backtrace
+        @test !isempty(read(tmp_output_filename, String))
+        close(tmp_output_file)
+        rm(tmp_output_filename)
     end
-    run(pipeline(`$(Base.julia_cmd()) --threads=4 --timeout-for-safepoint-straggler=1 -e $program`, stderr=tmp_output_file))
-    # Check whether we printed the straggler's backtrace
-    @test !isempty(read(tmp_output_filename, String))
-    close(tmp_output_file)
-    rm(tmp_output_filename)
 end
 
 end # main testset


### PR DESCRIPTION
## PR Description

Let's enable the safepoint straggler bt printing unconditionally.

## Checklist

Requirements for merging:
- [x] I have opened an issue or PR upstream on JuliaLang/julia: N/A.
- [x] I have removed the `port-to-*` labels that don't apply.
- [x] I have opened a PR on raicode to test these changes: https://github.com/RelationalAI/raicode/pull/23451.
