### PR TITLE
Show a backtrace where we're seeing a mysterious error

### DIFF
--- a/base/linked_list.jl
+++ b/base/linked_list.jl
@@ -50,7 +50,12 @@ function list_append!!(q::IntrusiveLinkedList{T}, q2::IntrusiveLinkedList{T}) wh
 end
 
 function push!(q::IntrusiveLinkedList{T}, val::T) where T
-    val.queue === nothing || error("val already in a list")
+    #val.queue === nothing || error("val already in a list")
+    if val.queue !== nothing
+        Base.show_backtrace(stderr, stacktrace(true))
+        println(stderr)
+        error("val already in a list")
+    end
     val.queue = q
     tail = q.tail
     if tail === nothing
@@ -63,7 +68,12 @@ function push!(q::IntrusiveLinkedList{T}, val::T) where T
 end
 
 function pushfirst!(q::IntrusiveLinkedList{T}, val::T) where T
-    val.queue === nothing || error("val already in a list")
+    #val.queue === nothing || error("val already in a list")
+    if val.queue !== nothing
+        Base.show_backtrace(stderr, stacktrace(true))
+        println(stderr)
+        error("val already in a list")
+    end
     val.queue = q
     head = q.head
     if head === nothing


### PR DESCRIPTION
<!---
PRs to RelationalAI/julia must be opened to the correct branch (see
https://github.com/RelationalAI/raicode/blob/master/nix/julia-version.json).
-->
## PR Description

To try and figure out what's causing [these](https://app.datadoghq.com/logs?query=service%3Arai-server%20%40rai.engine_name%3Atest_rel-distributed_eval-13816552136-1-q3yx2gsw-0&agg_m=count&agg_m_source=base&agg_q=%40rai.engine_name&agg_q_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&context_event=AZWLP5xdAAA4-m9TMr81UADE&event=AwAAAZWLP5ivVnxyNwAAABhBWldMUDV4ZEFBQTQtbTlUTXI4MVVBQzkAAAAkMDE5NThiNDYtYjVhOS00OWIyLWIyOTYtNzJkYmU5NjAxNDhmAAAR4g&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=time%2Cdesc&top_n=10&top_o=top&viz=&x_missing=true&from_ts=1741797600000&to_ts=1741798200000&live=false).

## Checklist

Requirements for merging:
- [ ] I have opened an issue or PR upstream on JuliaLang/julia: <link to JuliaLang/julia>
- [X] I have removed the `port-to-*` labels that don't apply.
- [X] I have opened a PR on raicode to test these changes: https://github.com/RelationalAI/raicode/pull/23598
