### PR TITLE
Use faster PRNG in the allocations profiler (#57761)

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -801,7 +801,7 @@ STATIC_INLINE void jl_array_grow_at_beg(jl_array_t *a, size_t idx, size_t inc,
     size_t nbinc = inc * elsz;
     char *data = (char*)a->data;
     char *newdata;
-    char *typetagdata;
+    char *typetagdata = NULL;
     char *newtypetagdata = NULL;
     int isbitsunion = jl_array_isbitsunion(a);
     if (isbitsunion) typetagdata = jl_array_typetagdata(a);

--- a/src/gc-alloc-profiler.cpp
+++ b/src/gc-alloc-profiler.cpp
@@ -138,7 +138,8 @@ void _maybe_record_alloc_to_profile(jl_value_t *val, size_t size, jl_datatype_t 
 
     auto& profile = global_profile.per_thread_profiles[thread_id];
 
-    auto sample_val = double(rand()) / double(RAND_MAX);
+    jl_ptls_t ptls = jl_current_task->ptls;
+    auto sample_val = double(cong(UINT64_MAX, &ptls->rngseed)) / double(UINT64_MAX);
     auto should_record = sample_val <= global_profile.sample_rate;
     if (!should_record) {
         return;

--- a/src/gc-alloc-profiler.cpp
+++ b/src/gc-alloc-profiler.cpp
@@ -139,7 +139,7 @@ void _maybe_record_alloc_to_profile(jl_value_t *val, size_t size, jl_datatype_t 
     auto& profile = global_profile.per_thread_profiles[thread_id];
 
     jl_ptls_t ptls = jl_current_task->ptls;
-    auto sample_val = double(cong(UINT64_MAX, &ptls->rngseed)) / double(UINT64_MAX);
+    auto sample_val = double(cong(UINT64_MAX, UINT64_MAX, &ptls->rngseed)) / double(UINT64_MAX);
     auto should_record = sample_val <= global_profile.sample_rate;
     if (!should_record) {
         return;


### PR DESCRIPTION
<!---
PRs to RelationalAI/julia must be opened to the correct branch (see
https://github.com/RelationalAI/raicode/blob/master/nix/julia-version.json).
-->
## PR Description

`rand()` locks and is slow. This uses the seed from `ptls`.

## Checklist

Requirements for merging:
- [X] I have opened an issue or PR upstream on JuliaLang/julia: https://github.com/JuliaLang/julia/pull/57761
- [X] I have removed the `port-to-*` labels that don't apply.
- [X] I have opened a PR on raicode to test these changes: https://github.com/RelationalAI/raicode/pull/23600
