### PR TITLE
[RAI-35987] Fix name canonicalization backport

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -225,11 +225,13 @@
                  (if lb (list lb ub) (list ub))
                  (if lb (list lb '(core Any)) '())))))
 
+;; Note that Scheme pairs representing a method in the AST are
+;; of the form (method name) or (method (outerref name)), at least in Julia 1.10.
 (define (is-method? x)
   (if (and (pair? x) (eq? (car x) 'method))
       (let ((name (cadr x)))
-        (if (and (pair? name) (eq? (car name) 'globalref))
-            (let ((name (caddr name)))
+        (if (and (pair? name) (eq? (car name) 'outerref))
+            (let ((name (cadr name)))
               (if (symbol? name)
                   #t
                   #f))


### PR DESCRIPTION
## PR Description

Fix a failure introduced in https://github.com/RelationalAI/julia/pull/179.

The function that checks whether an AST node represents a `method` was incorrect in that PR.

This PR passes the relevant `show` tests in JuliaLang CI.

```Julia
julia-RAI % julia                                     
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.10.2+RAI (2025-03-14)
 _/ |\__'_|_|_|\__'_|  |  dcn-fix-name-canonicalization/614e7b85c2 (fork: 430 commits, 620 days)
|__/                   |

julia> Base.runtests(["show"])
Running parallel tests with:
  nworkers() = 1
  nthreads() = 1
  Sys.CPU_THREADS = 4
  Sys.total_memory() = 64.000 GiB
  Sys.free_memory() = 13.791 GiB

Test  (Worker) | Time (s) | GC (s) | GC % | Alloc (MB) | RSS (MB)
show       (1) |        started at 2025-03-14T11:23:34.328
show       (1) |    11.59 |   0.19 |  1.6 |    2351.93 |   539.17

Test Summary: |   Pass  Broken   Total   Time
  Overall     | 129009       8  129017  12.2s
    SUCCESS
```

## Checklist

Requirements for merging:
- [x] I have opened an issue or PR upstream on JuliaLang/julia: N/A.
- [x] I have removed the `port-to-*` labels that don't apply.
- [x] I have opened a PR on raicode to test these changes: https://github.com/RelationalAI/raicode/pull/23627.
