### PR TITLE
[RAI-35958] Backport: Add passes to -O1 pipeline to reduce allocations in reinterpret

### DIFF
--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -459,6 +459,13 @@ static void buildScalarOptimizerPipeline(FunctionPassManager &FPM, PassBuilder *
         FPM.addPass(IRCEPass());
         FPM.addPass(InstCombinePass());
         FPM.addPass(JumpThreadingPass());
+    } else if (O.getSpeedupLevel() >= 1) {
+        JULIA_PASS(FPM.addPass(AllocOptPass()));
+        FPM.addPass(SROAPass());
+        FPM.addPass(MemCpyOptPass());
+        FPM.addPass(SCCPPass());
+        FPM.addPass(InstCombinePass());
+        FPM.addPass(ADCEPass());
     }
     if (O.getSpeedupLevel() >= 3) {
         FPM.addPass(GVNPass());


### PR DESCRIPTION
_What does this PR do?_

Port https://github.com/JuliaLang/julia/pull/57731.

Requirements for merging:
- [x] I have opened an issue or PR upstream on JuliaLang/julia: https://github.com/JuliaLang/julia/pull/57731.
- [x] I have removed the `port-to-*` labels that don't apply.
- [x] I have opened a PR on raicode to test these changes: https://github.com/RelationalAI/raicode/pull/23729.
