### PR TITLE
[Linux] Prevent GC from running during process teardown

### DIFF
--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -472,6 +472,7 @@ static int thread0_exit_signo = 0;
 static void JL_NORETURN jl_exit_thread0_cb(void)
 {
 CFI_NORETURN
+    jl_atomic_fetch_add(&jl_gc_disable_counter, -1);
     jl_critical_error(thread0_exit_signo, 0, NULL, jl_current_task);
     jl_atexit_hook(128);
     jl_raise(thread0_exit_signo);
@@ -963,6 +964,12 @@ static void *signal_listener(void *arg)
 //#if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 199309L && !HAVE_KEVENT
 //            si_code = info.si_code;
 //#endif
+            // Let's forbid threads from running GC while we're trying to exit,
+            // also let's make sure we're not in the middle of GC.
+            jl_atomic_fetch_add(&jl_gc_disable_counter, 1);
+            while (jl_atomic_load_acquire(&jl_gc_running)) {
+                jl_cpu_pause();
+            }
             jl_exit_thread0(sig, bt_data, bt_size);
         }
         else if (critical) {


### PR DESCRIPTION
## PR Description

Backports https://github.com/JuliaLang/julia/pull/57832 to fix the false alarms we've been getting in the GC crash monitor.

## Checklist

Requirements for merging:
- [x] I have opened an issue or PR upstream on JuliaLang/julia: https://github.com/JuliaLang/julia/pull/57832.
- [x] I have removed the `port-to-*` labels that don't apply.
- [x] I have opened a PR on raicode to test these changes: https://github.com/RelationalAI/raicode/pull/23681.
