### PR TITLE
Expose function to check if `precompile` guaranteed to fail (similar to `hasmethod`)

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2048,7 +2048,6 @@ function _require_from_serialized(uuidkey::PkgId, path::String, ocachepath::Unio
 end
 
 
-
 # relative-path load
 
 """
@@ -3206,6 +3205,27 @@ macro __DIR__()
     __source__.file === nothing && return nothing
     _dirname = dirname(String(__source__.file::Symbol))
     return isempty(_dirname) ? pwd() : abspath(_dirname)
+end
+
+# TODO: mark `public`?
+# TODO: name? isprecompilable? has_precompilable_specialization? has_precompilable_method?
+# TODO: put here next to `precompile` or in `reflection.jl` next to `hasmethod`?
+"""
+    precompilable(f, argtypes::Tuple{Vararg{Any}})::Bool
+
+Check if we can find a method instance for the given function `f` for the argument tuple
+(of types) `argtypes` that we can try to compile, but do not compile it.
+
+If `false`, then `precompile(f, argtypes)` would return `false`.
+If `true`, then `precompile(f, argtypes)` would try to compile a method specialization (but
+may still return `false` if it does not succeed).
+"""
+function precompilable(@nospecialize(f), @nospecialize(argtypes::Tuple))
+    precompile(Tuple{Core.Typeof(f), argtypes...})
+end
+
+function precompilable(@nospecialize(argt::Type))
+    return ccall(:jl_has_compile_hint_specialization, Int32, (Any,), argt) != 0
 end
 
 """

--- a/src/gf.c
+++ b/src/gf.c
@@ -2942,6 +2942,19 @@ JL_DLLEXPORT int jl_compile_hint(jl_tupletype_t *types)
     return 1;
 }
 
+// true if jl_get_compile_hint_specialization can find a method instance for us to try
+// to compile
+JL_DLLEXPORT int jl_has_compile_hint_specialization(jl_tupletype_t *types)
+{
+    size_t world = jl_atomic_load_acquire(&jl_world_counter);
+    size_t min_valid = 0;
+    size_t max_valid = ~(size_t)0;
+    jl_method_instance_t *mi = jl_get_compile_hint_specialization(types, world, &min_valid, &max_valid, 1);
+    if (mi == NULL)
+        return 0;
+    return 1;
+}
+
 // add type of `f` to front of argument tuple type
 jl_value_t *jl_argtype_with_function(jl_value_t *f, jl_value_t *types0)
 {

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -1057,3 +1057,17 @@ end
 @test !Base.ismutationfree(Vector{UInt64})
 
 @test Base.ismutationfree(Type{Union{}})
+
+module PrecompilableTest
+    foo(v::AbstractVector) = first(v) +1
+end
+@testset "precompilable" begin
+    @test !Base.precompilable(PrecompilableTest.foo, (AbstractVector,))
+    @test !Base.precompilable(PrecompilableTest.foo, (AbstractVector{Int},))
+    @test !Base.precompilable(PrecompilableTest.foo, (Vector,))
+    @test Base.precompilable(PrecompilableTest.foo, (Vector{Int},))
+    @test hasmethod(PrecompilableTest.foo, (AbstractVector,))
+    @test hasmethod(PrecompilableTest.foo, (AbstractVector{Int},))
+    @test hasmethod(PrecompilableTest.foo, (Vector,))
+    @test hasmethod(PrecompilableTest.foo, (Vector{Int},))
+end


### PR DESCRIPTION
## PR Description

**What does this PR do?**
adds a function to check if a `precompile` statement will have no effect

**use-case** 
- we want to precompile some subset specializations of a function (into our sysimg)
- since this is not all specialization we don't generate the list by reflection, but instead write them out by hand
- However, this is error-prone and liable to going stale... so the question is: how can we be sure the `precompile` calls are valid? 
- The safest way is: run the `precompiles` and throw is they fail, like `precompile(...) || @assert false` , but this means we have to actually wait for the compilation to happen (which is prohibitively slow)
- Is there a faster way that would still give us good signal? the most common way (we suspect) for hand written `precompile(f, argtypes)` to fail is because their _is no method specialization_ for `f` with those `argtypes` (as opposed to because compilation of such a method specialization fails), and that we can check with the function added in this PR!

i should run some timings but undoubtedly looking up a method specialization is the faster part compared to actually compiling, so this (I believe) strikes a good balance of being useful enough and fast enough.

We can't use `hasmethod` as it has both false positives (too loose):
```julia
julia> hasmethod(sum, (AbstractVector,))
true

julia> precompile(sum, (AbstractVector,))
false

julia> Base.precompilable(sum, (AbstractVector,)) # <- this PR
false
```
and also false negatives (too strict):
```julia
julia> bar(@nospecialize(x::AbstractVector{Int})) = 42
bar (generic function with 1 method)

julia> hasmethod(bar, (AbstractVector,))
false

julia> precompile(bar, (AbstractVector,))
true

julia> Base.precompilable(bar, (AbstractVector,)) # <- this PR
true
```
We can't use e.g. `hasmethod && isconcretype` as it has false negatives (too strict):
```julia
julia> has_concrete_method(f, argtypes) = all(isconcretetype, argtypes) && hasmethod(f, argtypes)
has_concrete_method (generic function with 1 method)

julia> has_concrete_method(bar, (AbstractVector,))
false

julia> has_concrete_method(convert, (Type{Int}, Int32))
false

julia> precompile(convert, (Type{Int}, Int32))
true

julia> Base.precompilable(convert, (Type{Int}, Int32))  # <- this PR
true
```

**Open questions**
- shall we open this PR upstream?
- what shall we name this? 
  - `isprecompilable`? `has_precompilable_specialization`? `has_precompilable_method`?
- where should the code live? in `loading.jl` next to `precompile` or in `reflection.jl` next to `hasmethod`?
- should we mark this `public` (if opened upstream)?

## Checklist

Requirements for merging:
- [ ] I have opened an issue or PR upstream on JuliaLang/julia: <link to JuliaLang/julia>
- [ ] I have removed the `port-to-*` labels that don't apply.
- [ ] I have opened a PR on raicode to test these changes: <link to raicode>
