### PR TITLE
Set safepoint straggler timeout to 25 secs

### DIFF
--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -94,7 +94,7 @@ JL_DLLEXPORT void jl_init_options(void)
                         0, // trace_compile_timing
                         NULL, // safe_crash_log_file
                         0, // task_metrics
-                        60, // timeout_for_safepoint_straggler_s
+                        25, // timeout_for_safepoint_straggler_s
     };
     jl_options_initialized = 1;
 }


### PR DESCRIPTION
<!---
PRs to RelationalAI/julia must be opened to the correct branch (see
https://github.com/RelationalAI/raicode/blob/master/nix/julia-version.json).
-->
## PR Description

Change the default from 60 seconds to 25 seconds.

## Checklist

Requirements for merging:
- [ ] I have opened an issue or PR upstream on JuliaLang/julia: <link to JuliaLang/julia>
- [X] I have removed the `port-to-*` labels that don't apply.
- [X] I have opened a PR on raicode to test these changes: https://github.com/RelationalAI/raicode/pull/24119
