### PR TITLE
Ignore inlining costs for precompilation with `--compile=all` (#53798)

### DIFF
--- a/src/precompile_utils.c
+++ b/src/precompile_utils.c
@@ -186,8 +186,7 @@ static int precompile_enq_specialization_(jl_method_instance_t *mi, void *closur
             jl_value_t *inferred = jl_atomic_load_relaxed(&codeinst->inferred);
             if (inferred &&
                 inferred != jl_nothing &&
-                jl_ir_flag_inferred(inferred) &&
-                (jl_ir_inlining_cost(inferred) == UINT16_MAX)) {
+                (jl_options.compile_enabled != JL_OPTIONS_COMPILE_ALL || jl_ir_inlining_cost(inferred) == UINT16_MAX)) {
                 do_compile = 1;
             }
             else if (jl_atomic_load_relaxed(&codeinst->invoke) != NULL || jl_atomic_load_relaxed(&codeinst->precompile)) {


### PR DESCRIPTION
<!---
PRs to RelationalAI/julia must be opened to the correct branch (see
https://github.com/RelationalAI/raicode/blob/master/nix/julia-version.json).
-->
## PR Description

This helps to minimize the amount of missed precompiles that occur by eliding the inlining cost check when julia is run under `--compile=all`. This will lead to
slightly larger sysimage sizes. However, in practice it leads to more extensive and successful precompilation, which can minimize the number of JIT events in
call sites with dynamic dispatch.

This is an alternative to #53547, where removing the inlining cost check was made universal. However, that lead to ~15% larger sysimage sizes by default. This implements Jeff's  suggestion that this mode be enabled under `--compile=all`.

Also added the fix to this PR mentioned [here](https://github.com/JuliaLang/julia/pull/53798#discussion_r1819780837).

## Checklist

Requirements for merging:
- [X] I have opened an issue or PR upstream on JuliaLang/julia: https://github.com/JuliaLang/julia/pull/53798
- [X] I have removed the `port-to-*` labels that don't apply.
- [ ] I have opened a PR on raicode to test these changes: <link to raicode>
