### PR TITLE
gf.c: include const-return methods in `--trace-compile`

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -476,6 +476,8 @@ JL_DLLEXPORT jl_code_instance_t *jl_get_method_inferred(
     return codeinst;
 }
 
+static void record_precompile_statement(jl_method_instance_t *mi, double compilation_time, int is_const_return_abi);
+
 JL_DLLEXPORT jl_code_instance_t *jl_new_codeinst(
         jl_method_instance_t *mi, jl_value_t *rettype,
         jl_value_t *inferred_const, jl_value_t *inferred,
@@ -501,6 +503,10 @@ JL_DLLEXPORT jl_code_instance_t *jl_new_codeinst(
     jl_atomic_store_relaxed(&codeinst->invoke, NULL);
     if ((const_flags & 1) != 0) {
         assert(const_flags & 2);
+        if (jl_is_method(mi->def.value) && jl_isa_compileable_sig((jl_tupletype_t *)mi->specTypes, mi->sparam_vals, mi->def.method)) {
+            // This code was freshly-inferred, so let's emit a `precompile(...)` statement for it
+            record_precompile_statement(mi, 0.0, 1);
+        }
         jl_atomic_store_relaxed(&codeinst->invoke, jl_fptr_const_return);
     }
     jl_atomic_store_relaxed(&codeinst->specsigflags, 0);
@@ -2392,7 +2398,7 @@ JL_DLLEXPORT void jl_force_trace_compile_timing_disable(void)
     jl_atomic_fetch_add(&jl_force_trace_compile_timing_enabled, -1);
 }
 
-static void record_precompile_statement(jl_method_instance_t *mi, double compilation_time)
+static void record_precompile_statement(jl_method_instance_t *mi, double compilation_time, int is_const_return_abi)
 {
     static ios_t f_precompile;
     static JL_STREAM* s_precompile = NULL;
@@ -2420,7 +2426,10 @@ static void record_precompile_statement(jl_method_instance_t *mi, double compila
             jl_printf(s_precompile, "#= %6.1f =# ", compilation_time / 1e6);
         jl_printf(s_precompile, "precompile(");
         jl_static_show(s_precompile, mi->specTypes);
-        jl_printf(s_precompile, ")\n");
+        if (is_const_return_abi)
+            jl_printf(s_precompile, ") #= const-return =#\n");
+        else
+            jl_printf(s_precompile, ")\n");
         if (s_precompile != JL_STDERR)
             ios_flush(&f_precompile);
     }
@@ -2566,7 +2575,7 @@ jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t 
                     codeinst->rettype_const = unspec->rettype_const;
                     jl_atomic_store_release(&codeinst->invoke, unspec_invoke);
                     jl_mi_cache_insert(mi, codeinst);
-                    record_precompile_statement(mi, 0);
+                    record_precompile_statement(mi, 0.0, 0);
                     return codeinst;
                 }
             }
@@ -2583,7 +2592,7 @@ jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t 
                 0, 1, ~(size_t)0, 0, 0, jl_nothing, 0);
             jl_atomic_store_release(&codeinst->invoke, jl_fptr_interpret_call);
             jl_mi_cache_insert(mi, codeinst);
-            record_precompile_statement(mi, 0);
+            record_precompile_statement(mi, 0.0, 0);
             return codeinst;
         }
         if (compile_option == JL_OPTIONS_COMPILE_OFF) {
@@ -2638,7 +2647,7 @@ jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t 
         jl_mi_cache_insert(mi, codeinst);
     }
     else if (did_compile) {
-        record_precompile_statement(mi, compile_time);
+        record_precompile_statement(mi, compile_time, 0);
     }
     jl_atomic_store_relaxed(&codeinst->precompile, 1);
     return codeinst;

--- a/src/gf.c
+++ b/src/gf.c
@@ -2426,10 +2426,7 @@ static void record_precompile_statement(jl_method_instance_t *mi, double compila
             jl_printf(s_precompile, "#= %6.1f =# ", compilation_time / 1e6);
         jl_printf(s_precompile, "precompile(");
         jl_static_show(s_precompile, mi->specTypes);
-        if (is_const_return_abi)
-            jl_printf(s_precompile, ") #= const-return =#\n");
-        else
-            jl_printf(s_precompile, ")\n");
+        jl_printf(s_precompile, ")\n");
         if (s_precompile != JL_STDERR)
             ios_flush(&f_precompile);
     }


### PR DESCRIPTION
<!---
PRs to RelationalAI/julia must be opened to the correct branch (see
https://github.com/RelationalAI/raicode/blob/master/nix/julia-version.json).
-->
## PR Description

This is a quick-fix for an issue where methods that are inferred to return a `Const` do not emit compilation traces. Although they are never compiled by LLVM, we want to log them since they are inferred / compiled by Julia. As with https://github.com/RelationalAI/julia/pull/236, it isn't yet clear what the actual upstream fix will look like on 1.12+.

## Checklist

Requirements for merging:
- [X] I have opened an issue or PR upstream on JuliaLang/julia: https://github.com/JuliaLang/julia/issues/58482
- [X] I have removed the `port-to-*` labels that don't apply.
- [X] I have opened a PR on raicode to test these changes: https://github.com/RelationalAI/raicode/pull/24463
