### PR TITLE
Don't filter `Core` methods from newly-inferred list

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -406,7 +406,7 @@ function cache_result!(interp::AbstractInterpreter, result::InferenceResult)
         code_cache(interp)[linfo] = ci = CodeInstance(interp, result, inferred_result, valid_worlds)
         if track_newly_inferred[]
             m = linfo.def
-            if isa(m, Method) && m.module != Core
+            if isa(m, Method)
                 ccall(:jl_push_newly_inferred, Cvoid, (Any,), ci)
             end
         end


### PR DESCRIPTION
<!---
PRs to RelationalAI/julia must be opened to the correct branch (see
https://github.com/RelationalAI/raicode/blob/master/nix/julia-version.json).
-->
## PR Description

Now that we re-export quite a lot from `Core` it seems sensible to remove. This allows constructors like `Tuple{Type{Vector{Foo}}, UndefInitializer, Tuple{Int}}` to precompile properly.

Appears to have a minimal effect on the stdlib pkgimages:
```julia
--- before.txt  2025-05-23 08:36:20.171870043 -0400
+++ after.txt   2025-05-22 14:48:49.003869097 -0400
@@ -47,7 +47,7 @@
  20K ../julia/usr/share/julia/compiled/v1.13/Logging/pkgimage.so
  20K ../julia/usr/share/julia/compiled/v1.13/Logging/pkgimage.so
 3.5M ../julia/usr/share/julia/compiled/v1.13/Markdown/pkgimage.so
-3.6M ../julia/usr/share/julia/compiled/v1.13/Markdown/pkgimage.so
+3.5M ../julia/usr/share/julia/compiled/v1.13/Markdown/pkgimage.so
 184K ../julia/usr/share/julia/compiled/v1.13/Mmap/pkgimage.so
 184K ../julia/usr/share/julia/compiled/v1.13/Mmap/pkgimage.so
  28K ../julia/usr/share/julia/compiled/v1.13/MozillaCACerts_jll/pkgimage.so
```

## Checklist

Requirements for merging:
- [X] I have opened an issue or PR upstream on JuliaLang/julia: https://github.com/JuliaLang/julia/pull/58510
- [X] I have removed the `port-to-*` labels that don't apply.
- [X] I have opened a PR on raicode to test these changes: https://github.com/RelationalAI/raicode/pull/24494
