### PR TITLE
Test Patch from Cody: Strip "CodeInstances with no machine code"

### DIFF
--- a/src/precompile_utils.c
+++ b/src/precompile_utils.c
@@ -182,7 +182,7 @@ static int precompile_enq_specialization_(jl_method_instance_t *mi, void *closur
     jl_code_instance_t *codeinst = jl_atomic_load_relaxed(&mi->cache);
     while (codeinst) {
         if (jl_atomic_load_relaxed(&codeinst->invoke) != jl_fptr_const_return) {
-            if (jl_atomic_load_relaxed(&codeinst->invoke) != NULL) {
+            if (jl_atomic_load_relaxed(&codeinst->invoke) != NULL || jl_atomic_load_relaxed(&codeinst->precompile)) {
                 jl_array_ptr_1d_push((jl_array_t*)closure, (jl_value_t*)mi);
                 return 1;
             }

--- a/src/precompile_utils.c
+++ b/src/precompile_utils.c
@@ -182,7 +182,7 @@ static int precompile_enq_specialization_(jl_method_instance_t *mi, void *closur
     jl_code_instance_t *codeinst = jl_atomic_load_relaxed(&mi->cache);
     while (codeinst) {
         if (jl_atomic_load_relaxed(&codeinst->invoke) != jl_fptr_const_return) {
-            if (jl_atomic_load_relaxed(&codeinst->invoke) != NULL || jl_atomic_load_relaxed(&codeinst->precompile)) {
+            if (jl_atomic_load_relaxed(&codeinst->invoke) != NULL) {
                 jl_array_ptr_1d_push((jl_array_t*)closure, (jl_value_t*)mi);
                 return 1;
             }

--- a/src/precompile_utils.c
+++ b/src/precompile_utils.c
@@ -181,22 +181,11 @@ static int precompile_enq_specialization_(jl_method_instance_t *mi, void *closur
     assert(jl_is_method_instance(mi));
     jl_code_instance_t *codeinst = jl_atomic_load_relaxed(&mi->cache);
     while (codeinst) {
-        int do_compile = 0;
         if (jl_atomic_load_relaxed(&codeinst->invoke) != jl_fptr_const_return) {
-            jl_value_t *inferred = jl_atomic_load_relaxed(&codeinst->inferred);
-            if (inferred &&
-                inferred != jl_nothing &&
-                jl_ir_flag_inferred(inferred) &&
-                (jl_ir_inlining_cost(inferred) == UINT16_MAX)) {
-                do_compile = 1;
+            if (jl_atomic_load_relaxed(&codeinst->invoke) != NULL || jl_atomic_load_relaxed(&codeinst->precompile)) {
+                jl_array_ptr_1d_push((jl_array_t*)closure, (jl_value_t*)mi);
+                return 1;
             }
-            else if (jl_atomic_load_relaxed(&codeinst->invoke) != NULL || jl_atomic_load_relaxed(&codeinst->precompile)) {
-                do_compile = 1;
-            }
-        }
-        if (do_compile) {
-            jl_array_ptr_1d_push((jl_array_t*)closure, (jl_value_t*)mi);
-            return 1;
         }
         codeinst = jl_atomic_load_relaxed(&codeinst->next);
     }

--- a/src/precompile_utils.c
+++ b/src/precompile_utils.c
@@ -184,14 +184,20 @@ static int precompile_enq_specialization_(jl_method_instance_t *mi, void *closur
         int do_compile = 0;
         if (jl_atomic_load_relaxed(&codeinst->invoke) != jl_fptr_const_return) {
             jl_value_t *inferred = jl_atomic_load_relaxed(&codeinst->inferred);
-            if (inferred &&
-                inferred != jl_nothing &&
-                jl_ir_flag_inferred(inferred) &&
-                (jl_ir_inlining_cost(inferred) == UINT16_MAX)) {
-                do_compile = 1;
-            }
-            else if (jl_atomic_load_relaxed(&codeinst->invoke) != NULL || jl_atomic_load_relaxed(&codeinst->precompile)) {
-                do_compile = 1;
+            if (getenv("JULIA_SERIALIZE_MACHINE_CODE_ONLY") != NULL) {
+                if (jl_atomic_load_relaxed(&codeinst->invoke) != NULL) {
+                    do_compile = 1;
+                }
+            } else {
+                if (inferred &&
+                    inferred != jl_nothing &&
+                    jl_ir_flag_inferred(inferred) &&
+                    (jl_ir_inlining_cost(inferred) == UINT16_MAX)) {
+                    do_compile = 1;
+                }
+                else if (jl_atomic_load_relaxed(&codeinst->invoke) != NULL || jl_atomic_load_relaxed(&codeinst->precompile)) {
+                    do_compile = 1;
+                }
             }
         }
         if (do_compile) {


### PR DESCRIPTION
## PR Description

Test Patch from @topolarity: Strip "CodeInstances with no machine code"

See: https://relationalai.slack.com/archives/C01BC96H69W/p1751057854696879?thread_ts=1750270043.364009&cid=C01BC96H69W

## Checklist

Requirements for merging:
- [ ] I have opened an issue or PR upstream on JuliaLang/julia: <link to JuliaLang/julia>
- [ ] I have removed the `port-to-*` labels that don't apply.
- [ ] I have opened a PR on raicode to test these changes: <link to raicode>
