### PR TITLE
[Observability] Include const-return methods in `--trace-compile` as logs only

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -476,6 +476,8 @@ JL_DLLEXPORT jl_code_instance_t *jl_get_method_inferred(
     return codeinst;
 }
 
+static void record_precompile_statement(jl_method_instance_t *mi, double compilation_time, double codegen_lock_waiting_time, int is_const_return_abi);
+
 JL_DLLEXPORT jl_code_instance_t *jl_new_codeinst(
         jl_method_instance_t *mi, jl_value_t *rettype,
         jl_value_t *inferred_const, jl_value_t *inferred,
@@ -501,6 +503,10 @@ JL_DLLEXPORT jl_code_instance_t *jl_new_codeinst(
     jl_atomic_store_relaxed(&codeinst->invoke, NULL);
     if ((const_flags & 1) != 0) {
         assert(const_flags & 2);
+        if (jl_is_method(mi->def.value) && jl_isa_compileable_sig((jl_tupletype_t *)mi->specTypes, mi->sparam_vals, mi->def.method)) {
+            // This code was freshly-inferred, so let's emit a `precompile(...)` statement for it
+            record_precompile_statement(mi, 0.0, 0.0, 1);
+        }
         jl_atomic_store_relaxed(&codeinst->invoke, jl_fptr_const_return);
     }
     jl_atomic_store_relaxed(&codeinst->specsigflags, 0);
@@ -2381,7 +2387,7 @@ JL_DLLEXPORT void jl_force_trace_compile_timing_disable(void)
     jl_atomic_fetch_add(&jl_force_trace_compile_timing_enabled, -1);
 }
 
-static void record_precompile_statement(jl_method_instance_t *mi, double compilation_time, double codegen_lock_waiting_time)
+static void record_precompile_statement(jl_method_instance_t *mi, double compilation_time, double codegen_lock_waiting_time, int is_const_return_abi)
 {
     static ios_t f_precompile;
     static JL_STREAM* s_precompile = NULL;
@@ -2413,7 +2419,7 @@ static void record_precompile_statement(jl_method_instance_t *mi, double compila
     if (!jl_has_free_typevars(mi->specTypes)) {
         if (force_trace_compile || jl_options.trace_compile_timing)
             jl_printf(s_precompile, "#= %6.1f =# ", compilation_time / 1e6);
-        jl_printf(s_precompile, "precompile(");
+        jl_printf(s_precompile, "%sprecompile(", is_const_return_abi ? "# const-return: " : "");
         jl_static_show(s_precompile, mi->specTypes);
         jl_printf(s_precompile, ")");
 
@@ -2588,7 +2594,7 @@ jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t 
                     codeinst->rettype_const = unspec->rettype_const;
                     jl_atomic_store_release(&codeinst->invoke, unspec_invoke);
                     jl_mi_cache_insert(mi, codeinst);
-                    record_precompile_statement(mi, 0, 0);
+                    record_precompile_statement(mi, 0.0, 0.0, 0);
                     return codeinst;
                 }
             }
@@ -2605,7 +2611,7 @@ jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t 
                 0, 1, ~(size_t)0, 0, 0, jl_nothing, 0);
             jl_atomic_store_release(&codeinst->invoke, jl_fptr_interpret_call);
             jl_mi_cache_insert(mi, codeinst);
-            record_precompile_statement(mi, 0, 0);
+            record_precompile_statement(mi, 0.0, 0.0, 0);
             return codeinst;
         }
         if (compile_option == JL_OPTIONS_COMPILE_OFF) {
@@ -2662,7 +2668,7 @@ jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t 
         jl_mi_cache_insert(mi, codeinst);
     }
     else if (did_compile) {
-        record_precompile_statement(mi, compile_time, (double)codegen_lock_waiting_time);
+        record_precompile_statement(mi, compile_time, (double)codegen_lock_waiting_time, 0);
     }
     jl_atomic_store_relaxed(&codeinst->precompile, 1);
     return codeinst;


### PR DESCRIPTION
## PR Description

These are never compiled by LLVM, but we want to log them since they are inferred / compiled by our own compiler.

Change to *only log* instead of emitting precompile

Note that this only emits 0.0 seconds, so not quite all of what we want.


## Checklist

Requirements for merging:
- [x] I have opened an issue or PR upstream on JuliaLang/julia: https://github.com/JuliaLang/julia/issues/58482
- [x] I have removed the `port-to-*` labels that don't apply.
- [x] I have opened a PR on raicode to test these changes: https://github.com/RelationalAI/raicode/pull/27429
